### PR TITLE
fix openai default model

### DIFF
--- a/lua/magenta/init.lua
+++ b/lua/magenta/init.lua
@@ -4,7 +4,7 @@ local M = {}
 M.defaults = {
   provider = "anthropic",
   openai = {
-    model = "4o"
+    model = "gpt-4o"
   },
   anthropic = {
     model = "claude-3-5-sonnet-20241022"


### PR DESCRIPTION
`4o` results in an no such model error.