### PR TITLE
Prompt caching

### DIFF
--- a/node/chat/__snapshots__/chat.spec.ts.snap
+++ b/node/chat/__snapshots__/chat.spec.ts.snap
@@ -437,9 +437,9 @@ exports[`tea/chat.spec.ts > chat render and a few updates 1`] = `
               "type": "string",
             },
             {
-              "content": ")",
+              "content": ") [input: ",
               "endPos": {
-                "col": 18,
+                "col": 27,
                 "row": 7,
               },
               "startPos": {
@@ -448,9 +448,69 @@ exports[`tea/chat.spec.ts > chat render and a few updates 1`] = `
               },
               "type": "string",
             },
+            {
+              "content": "0",
+              "endPos": {
+                "col": 28,
+                "row": 7,
+              },
+              "startPos": {
+                "col": 27,
+                "row": 7,
+              },
+              "type": "string",
+            },
+            {
+              "content": ", output: ",
+              "endPos": {
+                "col": 38,
+                "row": 7,
+              },
+              "startPos": {
+                "col": 28,
+                "row": 7,
+              },
+              "type": "string",
+            },
+            {
+              "content": "0",
+              "endPos": {
+                "col": 39,
+                "row": 7,
+              },
+              "startPos": {
+                "col": 38,
+                "row": 7,
+              },
+              "type": "string",
+            },
+            {
+              "content": "",
+              "endPos": {
+                "col": 39,
+                "row": 7,
+              },
+              "startPos": {
+                "col": 39,
+                "row": 7,
+              },
+              "type": "string",
+            },
+            {
+              "content": "]",
+              "endPos": {
+                "col": 40,
+                "row": 7,
+              },
+              "startPos": {
+                "col": 39,
+                "row": 7,
+              },
+              "type": "string",
+            },
           ],
           "endPos": {
-            "col": 18,
+            "col": 40,
             "row": 7,
           },
           "startPos": {
@@ -462,18 +522,18 @@ exports[`tea/chat.spec.ts > chat render and a few updates 1`] = `
         {
           "content": "",
           "endPos": {
-            "col": 18,
+            "col": 40,
             "row": 7,
           },
           "startPos": {
-            "col": 18,
+            "col": 40,
             "row": 7,
           },
           "type": "string",
         },
       ],
       "endPos": {
-        "col": 18,
+        "col": 40,
         "row": 7,
       },
       "startPos": {
@@ -484,516 +544,7 @@ exports[`tea/chat.spec.ts > chat render and a few updates 1`] = `
     },
   ],
   "endPos": {
-    "col": 18,
-    "row": 7,
-  },
-  "startPos": {
-    "col": 0,
-    "row": 0,
-  },
-  "type": "node",
-}
-`;
-
-exports[`tea/chat.spec.ts chat render and a few updates 1`] = `
-{
-  "children": [
-    {
-      "children": [
-        {
-          "children": [
-            {
-              "children": [
-                {
-                  "children": [
-                    {
-                      "content": "# ",
-                      "endPos": {
-                        "col": 2,
-                        "row": 0,
-                      },
-                      "startPos": {
-                        "col": 0,
-                        "row": 0,
-                      },
-                      "type": "string",
-                    },
-                    {
-                      "content": "user",
-                      "endPos": {
-                        "col": 6,
-                        "row": 0,
-                      },
-                      "startPos": {
-                        "col": 2,
-                        "row": 0,
-                      },
-                      "type": "string",
-                    },
-                    {
-                      "content": 
-":
-"
-,
-                      "endPos": {
-                        "col": 0,
-                        "row": 1,
-                      },
-                      "startPos": {
-                        "col": 6,
-                        "row": 0,
-                      },
-                      "type": "string",
-                    },
-                    {
-                      "children": [
-                        {
-                          "children": [
-                            {
-                              "children": [
-                                {
-                                  "content": "Can you look at my list of buffers?",
-                                  "endPos": {
-                                    "col": 35,
-                                    "row": 1,
-                                  },
-                                  "startPos": {
-                                    "col": 0,
-                                    "row": 1,
-                                  },
-                                  "type": "string",
-                                },
-                              ],
-                              "endPos": {
-                                "col": 35,
-                                "row": 1,
-                              },
-                              "startPos": {
-                                "col": 0,
-                                "row": 1,
-                              },
-                              "type": "node",
-                            },
-                            {
-                              "content": 
-"
-"
-,
-                              "endPos": {
-                                "col": 0,
-                                "row": 2,
-                              },
-                              "startPos": {
-                                "col": 35,
-                                "row": 1,
-                              },
-                              "type": "string",
-                            },
-                          ],
-                          "endPos": {
-                            "col": 0,
-                            "row": 2,
-                          },
-                          "startPos": {
-                            "col": 0,
-                            "row": 1,
-                          },
-                          "type": "node",
-                        },
-                      ],
-                      "endPos": {
-                        "col": 0,
-                        "row": 2,
-                      },
-                      "startPos": {
-                        "col": 0,
-                        "row": 1,
-                      },
-                      "type": "array",
-                    },
-                    {
-                      "content": "",
-                      "endPos": {
-                        "col": 0,
-                        "row": 2,
-                      },
-                      "startPos": {
-                        "col": 0,
-                        "row": 2,
-                      },
-                      "type": "string",
-                    },
-                  ],
-                  "endPos": {
-                    "col": 0,
-                    "row": 2,
-                  },
-                  "startPos": {
-                    "col": 0,
-                    "row": 0,
-                  },
-                  "type": "node",
-                },
-                {
-                  "content": 
-"
-"
-,
-                  "endPos": {
-                    "col": 0,
-                    "row": 3,
-                  },
-                  "startPos": {
-                    "col": 0,
-                    "row": 2,
-                  },
-                  "type": "string",
-                },
-              ],
-              "endPos": {
-                "col": 0,
-                "row": 3,
-              },
-              "startPos": {
-                "col": 0,
-                "row": 0,
-              },
-              "type": "node",
-            },
-            {
-              "children": [
-                {
-                  "children": [
-                    {
-                      "content": "# ",
-                      "endPos": {
-                        "col": 2,
-                        "row": 3,
-                      },
-                      "startPos": {
-                        "col": 0,
-                        "row": 3,
-                      },
-                      "type": "string",
-                    },
-                    {
-                      "content": "assistant",
-                      "endPos": {
-                        "col": 11,
-                        "row": 3,
-                      },
-                      "startPos": {
-                        "col": 2,
-                        "row": 3,
-                      },
-                      "type": "string",
-                    },
-                    {
-                      "content": 
-":
-"
-,
-                      "endPos": {
-                        "col": 0,
-                        "row": 4,
-                      },
-                      "startPos": {
-                        "col": 11,
-                        "row": 3,
-                      },
-                      "type": "string",
-                    },
-                    {
-                      "children": [
-                        {
-                          "children": [
-                            {
-                              "children": [
-                                {
-                                  "content": "Sure, let me use the list_buffers tool.",
-                                  "endPos": {
-                                    "col": 39,
-                                    "row": 4,
-                                  },
-                                  "startPos": {
-                                    "col": 0,
-                                    "row": 4,
-                                  },
-                                  "type": "string",
-                                },
-                              ],
-                              "endPos": {
-                                "col": 39,
-                                "row": 4,
-                              },
-                              "startPos": {
-                                "col": 0,
-                                "row": 4,
-                              },
-                              "type": "node",
-                            },
-                            {
-                              "content": 
-"
-"
-,
-                              "endPos": {
-                                "col": 0,
-                                "row": 5,
-                              },
-                              "startPos": {
-                                "col": 39,
-                                "row": 4,
-                              },
-                              "type": "string",
-                            },
-                          ],
-                          "endPos": {
-                            "col": 0,
-                            "row": 5,
-                          },
-                          "startPos": {
-                            "col": 0,
-                            "row": 4,
-                          },
-                          "type": "node",
-                        },
-                        {
-                          "children": [
-                            {
-                              "children": [
-                                {
-                                  "children": [
-                                    {
-                                      "content": "⚙️ Grabbing buffers...",
-                                      "endPos": {
-                                        "col": 26,
-                                        "row": 5,
-                                      },
-                                      "startPos": {
-                                        "col": 0,
-                                        "row": 5,
-                                      },
-                                      "type": "string",
-                                    },
-                                  ],
-                                  "endPos": {
-                                    "col": 26,
-                                    "row": 5,
-                                  },
-                                  "startPos": {
-                                    "col": 0,
-                                    "row": 5,
-                                  },
-                                  "type": "node",
-                                },
-                                {
-                                  "content": "",
-                                  "endPos": {
-                                    "col": 26,
-                                    "row": 5,
-                                  },
-                                  "startPos": {
-                                    "col": 26,
-                                    "row": 5,
-                                  },
-                                  "type": "string",
-                                },
-                                {
-                                  "content": "",
-                                  "endPos": {
-                                    "col": 26,
-                                    "row": 5,
-                                  },
-                                  "startPos": {
-                                    "col": 26,
-                                    "row": 5,
-                                  },
-                                  "type": "string",
-                                },
-                              ],
-                              "endPos": {
-                                "col": 26,
-                                "row": 5,
-                              },
-                              "startPos": {
-                                "col": 0,
-                                "row": 5,
-                              },
-                              "type": "node",
-                            },
-                            {
-                              "content": 
-"
-"
-,
-                              "endPos": {
-                                "col": 0,
-                                "row": 6,
-                              },
-                              "startPos": {
-                                "col": 26,
-                                "row": 5,
-                              },
-                              "type": "string",
-                            },
-                          ],
-                          "endPos": {
-                            "col": 0,
-                            "row": 6,
-                          },
-                          "startPos": {
-                            "col": 0,
-                            "row": 5,
-                          },
-                          "type": "node",
-                        },
-                      ],
-                      "endPos": {
-                        "col": 0,
-                        "row": 6,
-                      },
-                      "startPos": {
-                        "col": 0,
-                        "row": 4,
-                      },
-                      "type": "array",
-                    },
-                    {
-                      "content": "",
-                      "endPos": {
-                        "col": 0,
-                        "row": 6,
-                      },
-                      "startPos": {
-                        "col": 0,
-                        "row": 6,
-                      },
-                      "type": "string",
-                    },
-                  ],
-                  "endPos": {
-                    "col": 0,
-                    "row": 6,
-                  },
-                  "startPos": {
-                    "col": 0,
-                    "row": 3,
-                  },
-                  "type": "node",
-                },
-                {
-                  "content": 
-"
-"
-,
-                  "endPos": {
-                    "col": 0,
-                    "row": 7,
-                  },
-                  "startPos": {
-                    "col": 0,
-                    "row": 6,
-                  },
-                  "type": "string",
-                },
-              ],
-              "endPos": {
-                "col": 0,
-                "row": 7,
-              },
-              "startPos": {
-                "col": 0,
-                "row": 3,
-              },
-              "type": "node",
-            },
-          ],
-          "endPos": {
-            "col": 0,
-            "row": 7,
-          },
-          "startPos": {
-            "col": 0,
-            "row": 0,
-          },
-          "type": "array",
-        },
-        {
-          "children": [
-            {
-              "content": "Stopped (",
-              "endPos": {
-                "col": 9,
-                "row": 7,
-              },
-              "startPos": {
-                "col": 0,
-                "row": 7,
-              },
-              "type": "string",
-            },
-            {
-              "content": "end_turn",
-              "endPos": {
-                "col": 17,
-                "row": 7,
-              },
-              "startPos": {
-                "col": 9,
-                "row": 7,
-              },
-              "type": "string",
-            },
-            {
-              "content": ")",
-              "endPos": {
-                "col": 18,
-                "row": 7,
-              },
-              "startPos": {
-                "col": 17,
-                "row": 7,
-              },
-              "type": "string",
-            },
-          ],
-          "endPos": {
-            "col": 18,
-            "row": 7,
-          },
-          "startPos": {
-            "col": 0,
-            "row": 7,
-          },
-          "type": "node",
-        },
-        {
-          "content": "",
-          "endPos": {
-            "col": 18,
-            "row": 7,
-          },
-          "startPos": {
-            "col": 18,
-            "row": 7,
-          },
-          "type": "string",
-        },
-      ],
-      "endPos": {
-        "col": 18,
-        "row": 7,
-      },
-      "startPos": {
-        "col": 0,
-        "row": 0,
-      },
-      "type": "node",
-    },
-  ],
-  "endPos": {
-    "col": 18,
+    "col": 40,
     "row": 7,
   },
   "startPos": {

--- a/node/chat/chat.spec.ts
+++ b/node/chat/chat.spec.ts
@@ -35,7 +35,7 @@ describe("tea/chat.spec.ts", () => {
       expect(
         await buffer.getLines({ start: 0, end: -1 }),
         "initial render of chat works",
-      ).toEqual(["Stopped (end_turn)"] as Line[]);
+      ).toEqual(["Stopped (end_turn) [input: 0, output: 0]"] as Line[]);
 
       app.dispatch({
         type: "add-message",
@@ -74,7 +74,7 @@ describe("tea/chat.spec.ts", () => {
         "Sure, let me use the list_buffers tool.",
         "⚙️ Grabbing buffers...",
         "",
-        "Stopped (end_turn)",
+        "Stopped (end_turn) [input: 0, output: 0]",
       ] as Line[]);
 
       expect(
@@ -111,7 +111,7 @@ describe("tea/chat.spec.ts", () => {
         "Sure, let me use the list_buffers tool.",
         "✅ Finished getting buffers.",
         "",
-        "Stopped (end_turn)",
+        "Stopped (end_turn) [input: 0, output: 0]",
       ] as Line[]);
     });
   });
@@ -144,7 +144,7 @@ describe("tea/chat.spec.ts", () => {
       expect(
         await buffer.getLines({ start: 0, end: -1 }),
         "initial render of chat works",
-      ).toEqual(["Stopped (end_turn)"] as Line[]);
+      ).toEqual(["Stopped (end_turn) [input: 0, output: 0]"] as Line[]);
 
       app.dispatch({
         type: "add-message",
@@ -169,7 +169,7 @@ describe("tea/chat.spec.ts", () => {
         "# assistant:",
         "Sure, let me use the list_buffers tool.",
         "",
-        "Stopped (end_turn)",
+        "Stopped (end_turn) [input: 0, output: 0]",
       ] as Line[]);
 
       // expect(
@@ -184,7 +184,7 @@ describe("tea/chat.spec.ts", () => {
       expect(
         await buffer.getLines({ start: 0, end: -1 }),
         "finished render is as expected",
-      ).toEqual(["Stopped (end_turn)"] as Line[]);
+      ).toEqual(["Stopped (end_turn) [input: 0, output: 0]"] as Line[]);
 
       // expect(
       //   await extractMountTree(mountedApp.getMountedNode()),

--- a/node/magenta.spec.ts
+++ b/node/magenta.spec.ts
@@ -22,10 +22,12 @@ hello
 # assistant:
 sup?
 
-Stopped (end_turn)`);
+Stopped (end_turn) [input: 0, output: 0]`);
 
       await driver.clear();
-      await driver.assertDisplayBufferContent(`Stopped (end_turn)`);
+      await driver.assertDisplayBufferContent(
+        `Stopped (end_turn) [input: 0, output: 0]`,
+      );
       await driver.inputMagentaText(`hello again`);
       await driver.send();
       await driver.mockAnthropic.respond({
@@ -41,7 +43,7 @@ hello again
 # assistant:
 huh?
 
-Stopped (end_turn)`);
+Stopped (end_turn) [input: 0, output: 0]`);
     });
   });
 

--- a/node/providers/anthropic.spec.ts
+++ b/node/providers/anthropic.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { placeCacheBreakpoints } from "./anthropic.ts";
+import type { MessageParam } from "./anthropic.ts";
+
+describe("anthropic.ts", () => {
+  it("placeCacheBreakpoints should add cache markers at appropriate positions", () => {
+    const messages: MessageParam[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "a".repeat(4096), // ~1024 tokens
+          },
+          {
+            type: "text",
+            text: "b".repeat(4096), // Another ~1024 tokens
+          },
+          {
+            type: "text",
+            text: "c".repeat(8192), // Another ~2048 tokens
+          },
+        ],
+      },
+    ];
+
+    placeCacheBreakpoints(messages);
+
+    expect(messages[0].content[0].cache_control).toBeUndefined();
+
+    expect(messages[0].content[1].cache_control).toEqual({ type: "ephemeral" });
+
+    expect(messages[0].content[2].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("placeCacheBreakpoints should handle mixed content types", () => {
+    const messages: MessageParam[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "a".repeat(4096),
+          },
+          {
+            type: "tool_use",
+            name: "test_tool",
+            id: "123",
+            input: { param: "a".repeat(4096) },
+          },
+        ],
+      },
+    ];
+
+    placeCacheBreakpoints(messages);
+
+    expect(messages[0].content[0].cache_control).toBeUndefined();
+    expect(messages[0].content[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("placeCacheBreakpoints should not add cache markers for small content", () => {
+    const messages: MessageParam[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "short message",
+          },
+        ],
+      },
+    ];
+
+    placeCacheBreakpoints(messages);
+
+    expect(messages[0].content[0].cache_control).toBeUndefined();
+  });
+});

--- a/node/providers/anthropic.ts
+++ b/node/providers/anthropic.ts
@@ -105,6 +105,28 @@ export class AnthropicProvider implements Provider {
       };
     });
 
+    const tools: Anthropic.Tool[] = ToolManager.TOOL_SPECS.map(
+      (t, idx): Anthropic.Tool => {
+        if (idx == ToolManager.TOOL_SPECS.length - 1) {
+          /** Assuming that the ordering when the prompt is sent to anthropic will be:
+           * system
+           * tools
+           *
+           * So marking the last tool with cache_control should use the first cache breakpoint to tag the end of this opening section.
+           */
+          return {
+            ...t,
+            input_schema: t.input_schema as Anthropic.Messages.Tool.InputSchema,
+            cache_control: { type: "ephemeral" },
+          };
+        }
+        return {
+          ...t,
+          input_schema: t.input_schema as Anthropic.Messages.Tool.InputSchema,
+        };
+      },
+    );
+
     try {
       this.request = this.client.messages
         .stream({
@@ -116,7 +138,7 @@ export class AnthropicProvider implements Provider {
             type: "auto",
             disable_parallel_tool_use: false,
           },
-          tools: ToolManager.TOOL_SPECS as Anthropic.Tool[],
+          tools,
         })
         .on("text", (text: string) => {
           buf.push(text);

--- a/node/providers/anthropic.ts
+++ b/node/providers/anthropic.ts
@@ -108,20 +108,7 @@ export class AnthropicProvider implements Provider {
     });
 
     const tools: Anthropic.Tool[] = ToolManager.TOOL_SPECS.map(
-      (t, idx): Anthropic.Tool => {
-        if (idx == ToolManager.TOOL_SPECS.length - 1) {
-          /** Assuming that the ordering when the prompt is sent to anthropic will be:
-           * system
-           * tools
-           *
-           * So marking the last tool with cache_control should use the first cache breakpoint to tag the end of this opening section.
-           */
-          return {
-            ...t,
-            input_schema: t.input_schema as Anthropic.Messages.Tool.InputSchema,
-            cache_control: { type: "ephemeral" },
-          };
-        }
+      (t): Anthropic.Tool => {
         return {
           ...t,
           input_schema: t.input_schema as Anthropic.Messages.Tool.InputSchema,

--- a/node/providers/mock.ts
+++ b/node/providers/mock.ts
@@ -6,6 +6,7 @@ import {
   type Provider,
   type ProviderMessage,
   type StopReason,
+  type Usage,
 } from "./provider.ts";
 
 type MockRequest = {
@@ -15,6 +16,7 @@ type MockRequest = {
   defer: Defer<{
     toolRequests: Result<ToolRequest, { rawRequest: unknown }>[];
     stopReason: StopReason;
+    usage: Usage;
   }>;
 };
 
@@ -28,6 +30,10 @@ export class MockProvider implements Provider {
         lastRequest.defer.resolve({
           toolRequests: [],
           stopReason: "end_turn",
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+          },
         });
       }
     }
@@ -40,6 +46,7 @@ export class MockProvider implements Provider {
   ): Promise<{
     toolRequests: Result<ToolRequest, { rawRequest: unknown }>[];
     stopReason: StopReason;
+    usage: Usage;
   }> {
     const request: MockRequest = {
       messages,
@@ -79,6 +86,10 @@ export class MockProvider implements Provider {
     lastRequest.defer.resolve({
       toolRequests,
       stopReason,
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+      },
     });
   }
 }

--- a/node/providers/provider.ts
+++ b/node/providers/provider.ts
@@ -17,6 +17,13 @@ export type StopReason =
   | "content"
   | "stop_sequence";
 
+export type Usage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheHits?: number;
+  cacheMisses?: number;
+};
+
 export type ProviderMessage = {
   role: "user" | "assistant";
   content: string | Array<ProviderMessageContent>;
@@ -57,6 +64,7 @@ export interface Provider {
   ): Promise<{
     toolRequests: Result<ToolManager.ToolRequest, { rawRequest: unknown }>[];
     stopReason: StopReason;
+    usage: Usage;
   }>;
 
   abort(): void;


### PR DESCRIPTION
implementing prompt caching for anthropic.

Anthropic provides up to 4 cache breakpoints. I'm basically using them to mark off as much of the prompt as I can, in powers of 2.

So if the prompt is 5000 tokens, we'll put cache markers at messages at the 4096, 2048 and 1024 mark. (1024 being the minimum that anthropic can cache).

(see https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching for details)

I think this is a pretty decent strategy to make sure that we're reusing as much context as we can while allowing for things to change as files update and move up in the message stream (due to the smart context placement I implemented here: https://github.com/dlants/magenta.nvim/pull/24