### PR TITLE
feat: add support for telescope picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ TLDR:
 - `<leader>mt` is for `:Magenta toggle`, will toggle the sidebar on and off.
 - `<leader>mp` is for `:Magenta paste-selection`. In visual mode it will take the current selection and paste it into the input buffer.
 - `<leader>mb` is for `:Magenta context-files` with your _current_ file. It will pin the current file to your context.
-- `<leader>mf` is for `:Magenta context-files` it allows you to select files via fzf-lua, and will pin those files to your context. This requires that fzf-lua is installed.
+- `<leader>mf` is for `:Magenta context-files` it allows you to select files via fzf-lua or telescope, and will pin those files to your context. This requires that fzf-lua or telescope are installed.
 - `<leader>mc` is for `:Magenta clear`, which will clear the current chat.
 - `<leader>ma` is for `:Magenta abort`, which will abort the current in-flight request.
 

--- a/lua/magenta/utils.lua
+++ b/lua/magenta/utils.lua
@@ -37,4 +37,49 @@ M.log_job = function(log_level, is_stderr)
   end
 end
 
+M.fzf_files = function()
+  local fzf = require("fzf")
+  fzf.files(
+    {
+      raw = true, -- return just the raw path strings
+      actions = {
+        ["default"] = function(selected)
+          local escaped_files = {}
+          for _, entry in ipairs(selected) do
+            table.insert(escaped_files, vim.fn.shellescape(fzf.path.entry_to_file(entry).path))
+          end
+          vim.cmd("Magenta context-files " .. table.concat(escaped_files, " "))
+        end
+      }
+    }
+  )
+end
+
+M.telescope_files = function()
+  local builtin = require("telescope.builtin")
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+  builtin.find_files({
+    prompt_title = "Select context files",
+    attach_mappings = function(prompt_bufnr)
+      actions.select_default:replace(function()
+        local picker = action_state.get_current_picker(prompt_bufnr)
+        local selected_entries = picker:get_multi_selection()
+        if vim.tbl_isempty(selected_entries) then
+          selected_entries = { action_state.get_selected_entry() }
+        end
+        actions.close(prompt_bufnr)
+        local escaped_files = {}
+        for _, entry in ipairs(selected_entries) do
+          table.insert(escaped_files, vim.fn.shellescape(entry.path))
+        end
+        if not vim.tbl_isempty(escaped_files) then
+          vim.cmd("Magenta context-files " .. table.concat(escaped_files, " "))
+        end
+      end)
+      return true
+    end,
+  })
+end
+
 return M


### PR DESCRIPTION
Adds support for telescope as a backend for `context-files`. The plugin will first search for fzf-lua, and then for telescope. It will use the first it finds (so still defaults to fzf-lua). Can pass a `picker` option to force the choice as well.

I was going to apply the same change to `Magenta provider`, but after looking at it, it seems to me using the builtin `vim.ui.select` (which can be set to use fzf-lua, telescope, or any other provider) is more suitable for this use case.