### PR TITLE
feat: improve config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,24 +72,127 @@ vim.call('plug#end')
 require('magenta').setup()
 ```
 
+# Config
+
+<details>
+<summary>Default options</summary>
+
+```lua
+require('magenta').setup({
+  provider = "anthropic",
+  openai = {
+    model = "gpt-4o"
+  },
+  anthropic = {
+    model = "claude-3-5-sonnet-20241022"
+  },
+  bedrock = {
+    model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    promptCaching = false
+  },
+  -- can be changed to "telescope"
+  picker = "fzf-lua",
+  -- enable default keymaps shown below
+  default_keymaps = true,
+  -- keymaps for the sidebar input buffer
+  sidebar_keymaps = {
+    normal = {
+      ["<CR>"] = ":Magenta send<CR>",
+    }
+  },
+  -- keymaps for the inline edit input buffer
+  -- if keymap is set to function, it accpets a target_bufnr param
+  inline_keymaps =  {
+    normal = {
+      ["<CR>"] = function(target_bufnr)
+        vim.cmd("Magenta submit-inline-edit " .. target_bufnr)
+      end,
+    },
+  }
+})
+```
+
+</details>
+
+If `default_keymaps` is set to true, the plugin will configure the following global keymaps:
+
+<details>
+<summary>Default keymaps</summary>
+
+```lua
+local Actions = require("magenta.actions")
+
+vim.keymap.set(
+  "n",
+  "<leader>mc",
+  ":Magenta clear<CR>",
+  {silent = true, noremap = true, desc = "Clear Magenta state"}
+)
+
+vim.keymap.set(
+  "n",
+  "<leader>ma",
+  ":Magenta abort<CR>",
+  {silent = true, noremap = true, desc = "Abort current Magenta operation"}
+)
+
+vim.keymap.set(
+  "n",
+  "<leader>mt",
+  ":Magenta toggle<CR>",
+  {silent = true, noremap = true, desc = "Toggle Magenta window"}
+)
+
+vim.keymap.set(
+  "n",
+  "<leader>mi",
+  ":Magenta start-inline-edit<CR>",
+  {silent = true, noremap = true, desc = "Inline edit"}
+)
+
+vim.keymap.set(
+  "v",
+  "<leader>mi",
+  ":Magenta start-inline-edit-selection<CR>",
+  {silent = true, noremap = true, desc = "Inline edit selection"}
+)
+
+vim.keymap.set(
+  "v",
+  "<leader>mp",
+  ":Magenta paste-selection<CR>",
+  {silent = true, noremap = true, desc = "Send selection to Magenta"}
+)
+
+vim.keymap.set(
+  "n",
+  "<leader>mb", -- like "magenta buffer"?
+  Actions.add_buffer_to_context,
+  { noremap = true, silent = true, desc = "Add current buffer to Magenta context" }
+)
+
+vim.keymap.set(
+  "n",
+  "<leader>mf",
+  Actions.pick_context_files,
+  { noremap = true, silent = true, desc = "Select files to add to Magenta context" }
+)
+
+vim.keymap.set(
+  "n",
+  "<leader>mp",
+  Actions.pick_provider,
+  { noremap = true, silent = true, desc = "Select provider and model" }
+)
+```
+
+</details>
+
 # Usage
 
-## keymaps
+### Chat
 
-Global keymaps are set [here](https://github.com/dlants/magenta.nvim/blob/main/lua/magenta/init.lua#L12).
-
-Input and display buffer keymaps are set [here](https://github.com/dlants/magenta.nvim/blob/main/node/sidebar.ts#L87).
-
-Commands are all nested under `:Magenta <cmd>`, and can be found [here](https://github.com/dlants/magenta.nvim/blob/main/node/magenta.ts#L54).
-
-TLDR:
-
-- `<leader>mt` is for `:Magenta toggle`, will toggle the sidebar on and off.
-- `<leader>mp` is for `:Magenta paste-selection`. In visual mode it will take the current selection and paste it into the input buffer.
-- `<leader>mb` is for `:Magenta context-files` with your _current_ file. It will pin the current file to your context.
-- `<leader>mf` is for `:Magenta context-files` it allows you to select files via fzf-lua or telescope, and will pin those files to your context. This requires that fzf-lua or telescope are installed.
-- `<leader>mc` is for `:Magenta clear`, which will clear the current chat.
-- `<leader>ma` is for `:Magenta abort`, which will abort the current in-flight request.
+- `<leader>mt` is for `:Magenta toggle`. This will open a sidebar where you can chat with the model. You can add files to the context with `Magenta context-files` (`<leader>mf`), or paste your current visual selection with `Magenta paste-selection` (`<leader>mp`)
 
 ### Inline edit
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ require('magenta').setup({
   },
   bedrock = {
     model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
-    promptCaching = false
+    prompt_caching = false
   },
+  -- open chat sidebar on left or right side
+  sidebar_position = "left",
   -- can be changed to "telescope"
   picker = "fzf-lua",
   -- enable default keymaps shown below

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require('magenta').setup({
     model = "gpt-4o"
   },
   anthropic = {
-    model = "claude-3-5-sonnet-20241022"
+    model = "claude-3-5-sonnet-latest"
   },
   bedrock = {
     model = "anthropic.claude-3-5-sonnet-20241022-v2:0",

--- a/lua/magenta/actions.lua
+++ b/lua/magenta/actions.lua
@@ -1,0 +1,80 @@
+local M = {}
+
+local Options = require("magenta.options")
+
+local fzf_files = function()
+  local fzf = require("fzf-lua")
+  fzf.files(
+    {
+      raw = true, -- return just the raw path strings
+      actions = {
+        ["default"] = function(selected)
+          local escaped_files = {}
+          for _, entry in ipairs(selected) do
+            table.insert(escaped_files, vim.fn.shellescape(fzf.path.entry_to_file(entry).path))
+          end
+          vim.cmd("Magenta context-files " .. table.concat(escaped_files, " "))
+        end
+      }
+    }
+  )
+end
+
+local telescope_files = function()
+  local builtin = require("telescope.builtin")
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+  builtin.find_files({
+    prompt_title = "Select context files",
+    attach_mappings = function(prompt_bufnr)
+      actions.select_default:replace(function()
+        local picker = action_state.get_current_picker(prompt_bufnr)
+        local selected_entries = picker:get_multi_selection()
+        if vim.tbl_isempty(selected_entries) then
+          selected_entries = { action_state.get_selected_entry() }
+        end
+        actions.close(prompt_bufnr)
+        local escaped_files = {}
+        for _, entry in ipairs(selected_entries) do
+          table.insert(escaped_files, vim.fn.shellescape(entry.path))
+        end
+        if not vim.tbl_isempty(escaped_files) then
+          vim.cmd("Magenta context-files " .. table.concat(escaped_files, " "))
+        end
+      end)
+      return true
+    end,
+  })
+end
+
+
+M.pick_context_files = function()
+  if Options.options.picker == "fzf-lua" then
+    fzf_files()
+  elseif Options.options.picker == "telescope" then
+    telescope_files()
+  else
+    vim.notify("Neither fzf-lua nor telescope are installed!", vim.log.levels.ERROR)
+  end
+end
+
+M.pick_provider = function()
+  local items = {
+    'openai gpt-4o',
+    'openai o1',
+    'openai o1-mini',
+    'anthropic claude-3-5-sonnet-latest'
+  }
+  vim.ui.select(items, { prompt = "Select Model", }, function (choice)
+    if choice ~= nil then
+      vim.cmd("Magenta provider " .. choice )
+    end
+  end)
+end
+
+M.add_buffer_to_context = function()
+  local current_file = vim.fn.expand("%:p")
+  vim.cmd("Magenta context-files " .. vim.fn.shellescape(current_file))
+end
+
+return M

--- a/lua/magenta/init.lua
+++ b/lua/magenta/init.lua
@@ -94,7 +94,8 @@ M.bridge = function(channelId)
     provider = opts.provider,
     anthropic = opts.anthropic,
     openai = opts.openai,
-    bedrock = opts.bedrock
+    bedrock = opts.bedrock,
+    sidebar_position = opts.sidebar_position
   }
 end
 

--- a/lua/magenta/keymaps.lua
+++ b/lua/magenta/keymaps.lua
@@ -98,7 +98,6 @@ end
 M.set_sidebar_buffer_keymaps = function(bufnr)
   for mode, values in pairs(Options.options.sidebar_keymaps) do
     for key, action in pairs(values) do
-      print("setting keymap", mode, key, action)
       vim.keymap.set(
         mode_to_keymap[mode],
         key,

--- a/lua/magenta/keymaps.lua
+++ b/lua/magenta/keymaps.lua
@@ -1,0 +1,113 @@
+local M = {}
+
+local Actions = require("magenta.actions")
+local Options = require("magenta.options")
+
+M.default_keymaps = function()
+  vim.keymap.set(
+    "n",
+    "<leader>mc",
+    ":Magenta clear<CR>",
+    {silent = true, noremap = true, desc = "Clear Magenta state"}
+  )
+
+  vim.keymap.set(
+    "n",
+    "<leader>ma",
+    ":Magenta abort<CR>",
+    {silent = true, noremap = true, desc = "Abort current Magenta operation"}
+  )
+
+  vim.keymap.set(
+    "n",
+    "<leader>mt",
+    ":Magenta toggle<CR>",
+    {silent = true, noremap = true, desc = "Toggle Magenta window"}
+  )
+
+  vim.keymap.set(
+    "n",
+    "<leader>mi",
+    ":Magenta start-inline-edit<CR>",
+    {silent = true, noremap = true, desc = "Inline edit"}
+  )
+
+  vim.keymap.set(
+    "v",
+    "<leader>mi",
+    ":Magenta start-inline-edit-selection<CR>",
+    {silent = true, noremap = true, desc = "Inline edit selection"}
+  )
+
+  vim.keymap.set(
+    "v",
+    "{leader}mp",
+    ":Magenta paste-selection{CR}",
+    {silent = true, noremap = true, desc = "Send selection to Magenta"}
+  )
+
+  vim.keymap.set(
+    "n",
+    "<leader>mb", -- like "magenta buffer"?
+    Actions.add_buffer_to_context,
+    {silent = true, noremap = true, desc = "Add current buffer to Magenta context"}
+  )
+
+  vim.keymap.set(
+    "n",
+    "<leader>mf",
+    Actions.pick_context_files,
+    {silent = true, noremap = true, desc = "Select files to add to Magenta context"}
+  )
+
+  vim.keymap.set(
+    "n",
+    "<leader>mp",
+    Actions.pick_provider,
+    {silent = true, noremap = true, desc = "Select provider and model"}
+  )
+end
+
+local mode_to_keymap = {
+  normal = "n",
+  visual = "v",
+  insert = "i",
+  command = "c",
+}
+
+M.set_inline_buffer_keymaps = function(bufnr, target_bufnr)
+  for mode, values in pairs(Options.options.inline_keymaps) do
+    for key, _action in pairs(values) do
+      local action = _action
+      if type(_action) == "function" then
+        action = function()
+          _action(target_bufnr)
+        end
+      end
+      vim.keymap.set(
+        mode_to_keymap[mode],
+        key,
+        action,
+        {buffer = bufnr, noremap = true, silent = true}
+      )
+    end
+  end
+end
+
+
+M.set_sidebar_buffer_keymaps = function(bufnr)
+  for mode, values in pairs(Options.options.sidebar_keymaps) do
+    for key, action in pairs(values) do
+      print("setting keymap", mode, key, action)
+      vim.keymap.set(
+        mode_to_keymap[mode],
+        key,
+        action,
+        {buffer = bufnr, noremap = true, silent = true}
+      )
+    end
+  end
+end
+
+
+return M

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -6,7 +6,7 @@ local defaults = {
     model = "gpt-4o"
   },
   anthropic = {
-    model = "claude-3-5-sonnet-20241022"
+    model = "claude-3-5-sonnet-latest"
   },
   bedrock = {
     model = "anthropic.claude-3-5-sonnet-20241022-v2:0",

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -1,0 +1,48 @@
+local M = {}
+
+local defaults = {
+  provider = "anthropic",
+  openai = {
+    model = "gpt-4o"
+  },
+  anthropic = {
+    model = "claude-3-5-sonnet-20241022"
+  },
+  bedrock = {
+    model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    promptCaching = false
+  },
+  picker = "fzf-lua",
+  default_keymaps = true,
+  sidebar_keymaps = {
+    normal = {
+      ["<CR>"] = ":Magenta send<CR>",
+    }
+  },
+  inline_keymaps = {
+    normal = {
+      ["<CR>"] = function(target_bufnr)
+        vim.cmd("Magenta submit-inline-edit " .. target_bufnr)
+      end,
+    },
+  }
+}
+
+M.options = defaults
+
+M.set_options = function(opts)
+  M.options = vim.tbl_deep_extend("force", defaults, opts or {})
+  if (opts.picker == nil) then
+    local success, _ = pcall(require, "fzf-lua")
+    if success then
+      M.options.picker = "fzf-lua"
+    else
+      success, _ = pcall(require, "telescope")
+      if success then
+        M.options.picker = "telescope"
+      end
+    end
+  end
+end
+
+return M

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -10,9 +10,10 @@ local defaults = {
   },
   bedrock = {
     model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
-    promptCaching = false
+    prompt_caching = false
   },
   picker = "fzf-lua",
+  sidebar_position = "right",
   default_keymaps = true,
   sidebar_keymaps = {
     normal = {

--- a/lua/magenta/utils.lua
+++ b/lua/magenta/utils.lua
@@ -37,49 +37,4 @@ M.log_job = function(log_level, is_stderr)
   end
 end
 
-M.fzf_files = function()
-  local fzf = require("fzf")
-  fzf.files(
-    {
-      raw = true, -- return just the raw path strings
-      actions = {
-        ["default"] = function(selected)
-          local escaped_files = {}
-          for _, entry in ipairs(selected) do
-            table.insert(escaped_files, vim.fn.shellescape(fzf.path.entry_to_file(entry).path))
-          end
-          vim.cmd("Magenta context-files " .. table.concat(escaped_files, " "))
-        end
-      }
-    }
-  )
-end
-
-M.telescope_files = function()
-  local builtin = require("telescope.builtin")
-  local actions = require("telescope.actions")
-  local action_state = require("telescope.actions.state")
-  builtin.find_files({
-    prompt_title = "Select context files",
-    attach_mappings = function(prompt_bufnr)
-      actions.select_default:replace(function()
-        local picker = action_state.get_current_picker(prompt_bufnr)
-        local selected_entries = picker:get_multi_selection()
-        if vim.tbl_isempty(selected_entries) then
-          selected_entries = { action_state.get_selected_entry() }
-        end
-        actions.close(prompt_bufnr)
-        local escaped_files = {}
-        for _, entry in ipairs(selected_entries) do
-          table.insert(escaped_files, vim.fn.shellescape(entry.path))
-        end
-        if not vim.tbl_isempty(escaped_files) then
-          vim.cmd("Magenta context-files " .. table.concat(escaped_files, " "))
-        end
-      end)
-      return true
-    end,
-  })
-end
-
 return M

--- a/node/inline-edit/inline-edit-manager.ts
+++ b/node/inline-edit/inline-edit-manager.ts
@@ -106,12 +106,7 @@ export class InlineEditManager {
     await this.nvim.call("nvim_exec2", ["startinsert", {}]);
 
     // Set up <CR> mapping in normal mode
-    await inputBuffer.setKeymap({
-      mode: "n",
-      lhs: "<CR>",
-      rhs: `:Magenta submit-inline-edit ${targetBufnr}<CR>`,
-      opts: { silent: true, noremap: true },
-    });
+    await inputBuffer.setInlineKeymaps(targetBufnr);
 
     let selectionWithText: InlineEditState["selection"];
     if (selection) {

--- a/node/magenta.ts
+++ b/node/magenta.ts
@@ -134,7 +134,7 @@ export class Magenta {
       }
 
       case "toggle": {
-        const buffers = await this.sidebar.toggle();
+        const buffers = await this.sidebar.toggle(this.options.sidebarPosition);
         if (buffers && !this.mountedChatApp) {
           this.mountedChatApp = await this.chatApp.mount({
             nvim: this.nvim,

--- a/node/nvim/buffer.ts
+++ b/node/nvim/buffer.ts
@@ -106,26 +106,17 @@ export class NvimBuffer {
     ]);
   }
 
-  setKeymap({
-    mode,
-    lhs,
-    rhs,
-    opts,
-  }: {
-    mode: Mode;
-    lhs: string;
-    rhs: string;
-    opts: {
-      silent?: boolean;
-      noremap?: boolean;
-    };
-  }) {
-    return this.nvim.call("nvim_buf_set_keymap", [
-      this.id,
-      mode,
-      lhs,
-      rhs,
-      opts,
+  setSiderbarKeymaps() {
+    return this.nvim.call("nvim_exec_lua", [
+      `require("magenta.keymaps").set_sidebar_buffer_keymaps(${this.id})`,
+      [],
+    ]);
+  }
+
+  setInlineKeymaps(targetBufnr: BufNr) {
+    return this.nvim.call("nvim_exec_lua", [
+      `require("magenta.keymaps").set_inline_buffer_keymaps(${this.id}, ${targetBufnr})`,
+      [],
     ]);
   }
 

--- a/node/options.ts
+++ b/node/options.ts
@@ -5,6 +5,7 @@ export type MagentaOptions = {
   openai: { model: string };
   anthropic: { model: string };
   bedrock: { model: string; promptCaching: boolean };
+  sidebarPosition: "left" | "right";
 };
 
 export const DEFAULT_OPTIONS: MagentaOptions = {
@@ -19,6 +20,7 @@ export const DEFAULT_OPTIONS: MagentaOptions = {
     model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
     promptCaching: false,
   },
+  sidebarPosition: "left",
 };
 
 export function parseOptions(inputOptions: unknown): MagentaOptions {
@@ -26,6 +28,10 @@ export function parseOptions(inputOptions: unknown): MagentaOptions {
 
   if (typeof inputOptions == "object" && inputOptions != null) {
     const inputOptionsObj = inputOptions as { [key: string]: unknown };
+    const sidebarPosition = inputOptionsObj["sidebar_position"];
+    if (sidebarPosition === "right" || sidebarPosition === "left") {
+      options.sidebarPosition = sidebarPosition;
+    }
     if (
       typeof inputOptionsObj["provider"] == "string" &&
       PROVIDER_NAMES.indexOf(inputOptionsObj["provider"] as ProviderName) != -1
@@ -58,8 +64,8 @@ export function parseOptions(inputOptions: unknown): MagentaOptions {
       if (typeof bedrockOptions["model"] == "string") {
         options.bedrock.model = bedrockOptions.model;
       }
-      if (typeof bedrockOptions["promptCaching"] == "boolean") {
-        options.bedrock.promptCaching = bedrockOptions.promptCaching;
+      if (typeof bedrockOptions["prompt_caching"] == "boolean") {
+        options.bedrock.promptCaching = bedrockOptions.prompt_caching;
       }
     }
   }

--- a/node/sidebar.ts
+++ b/node/sidebar.ts
@@ -105,12 +105,7 @@ export class Sidebar {
       await inputBuffer.setOption("buftype", "nofile");
       await inputBuffer.setOption("swapfile", false);
       await inputBuffer.setOption("filetype", "markdown");
-      await inputBuffer.setKeymap({
-        mode: "n",
-        lhs: "<CR>",
-        rhs: ":Magenta send<CR>",
-        opts: { silent: true, noremap: true },
-      });
+      await inputBuffer.setSiderbarKeymaps();
     }
 
     const inputWindowId = (await this.nvim.call("nvim_open_win", [

--- a/node/sidebar.ts
+++ b/node/sidebar.ts
@@ -48,18 +48,20 @@ export class Sidebar {
 
   /** returns buffers when they are visible
    */
-  async toggle(): Promise<
+  async toggle(
+    sidebarPosition: "left" | "right",
+  ): Promise<
     { displayBuffer: NvimBuffer; inputBuffer: NvimBuffer } | undefined
   > {
     if (this.state.state == "hidden") {
-      return await this.show();
+      return await this.show(sidebarPosition);
     } else {
       await this.hide();
       return undefined;
     }
   }
 
-  private async show(): Promise<{
+  private async show(sidebarPosition: "left" | "right"): Promise<{
     displayBuffer: NvimBuffer;
     inputBuffer: NvimBuffer;
   }> {
@@ -88,7 +90,7 @@ export class Sidebar {
       false,
       {
         win: -1, // global split
-        split: "left",
+        split: sidebarPosition,
         width: WIDTH,
         height: displayHeight,
         style: "minimal",


### PR DESCRIPTION
### Features
* Allow disabling default global keymaps 
* Allow overriding / extending sidebar / inline buffer keymaps
* Option to open the side bar on left / right side (default of 'left' unchanged)
* Update README with config options

### Changes
I've added keymaps.lua where I've moved all the keymaps declarations. For the buffer mappings, they can be provided as a table in the config. Instead of defining them directly from TS, added 2 new set_buffer_keymaps functions that are invoked instead (as we can't pass serialized functions to ts easily)

Added actions.lua where I've moved some of the keymap logic to mantain the keymap definitions as commands or one liners