### PR TITLE
feat: disable startup logs

### DIFF
--- a/lua/magenta/utils.lua
+++ b/lua/magenta/utils.lua
@@ -26,6 +26,10 @@ M.log_job = function(log_level, is_stderr)
       table.insert(lines, data[i])
     end
     if eof then
+      -- don't log the init message
+      if #lines >=2 and lines[2]:match("magenta.nvim@.*start") then
+        return
+      end
       local prefix = is_stderr and "[ERROR]" or "[INFO]"
       vim.print("----------------")
       vim.print(string.format("%s job# %d:", prefix, job_id))

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "scripts": {
-    "start": "npx tsx node/index.ts"
+    "start": "npx tsx --no-deprecation node/index.ts"
   },
   "version": "0.0.0",
   "description": "an AI agent / LLM coding assistant for neovim",


### PR DESCRIPTION
Currently, magenta emits the following message on startup:

```
----------------
[INFO] job# 3:
> magenta.nvim@0.0.0 start
> npx tsx node/index.ts
----------------
[ERROR] job# 3:
(node:22097) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

This is a bit annoying as it pollutes the output of `:messages`. To fix this without disabling regular logs / errors coming from node:

* hardcoded a check on log_line that suppreses the initial start command log
* punycode is deprecated on the latest node LTS (22). Added `--no-deprecation` to `tsx` to suppress it