### PR TITLE
user-defined models list, o1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,19 +98,19 @@ require('magenta').setup({
         model = "o1",
         -- some openai models, like o1, error out when `parallel_tool_calls` param is provided
         -- optionally omit it:
-        omitParallelToolCalls = true
+        omit_parallel_tool_calls = true
       },
     },
-	anthropic = {
-	  { model = "claude-3-7-sonnet-latest" },
-	  { model = "claude-3-5-sonnet-latest" },
-	},
-	bedrock = {
-	  {
+    anthropic = {
+      { model = "claude-3-7-sonnet-latest" },
+      { model = "claude-3-5-sonnet-latest" },
+    },
+    bedrock = {
+      {
         model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
         prompt_caching = false
       },
-	},
+    },
   },
 
   -- open chat sidebar on left or right side

--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ require('magenta').setup({
     model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
     prompt_caching = false
   },
+  -- models available to choose from
+  models = {
+    openai = {
+      { model = "gpt-4o" },
+      {
+        model = "o1",
+        -- some openai models, like o1, error out when `parallel_tool_calls` param is provided
+        -- optionally omit it:
+        omitParallelToolCalls = true
+      },
+    },
+	anthropic = {
+	  { model = "claude-3-7-sonnet-latest" },
+	  { model = "claude-3-5-sonnet-latest" },
+	},
+	bedrock = {
+	  {
+        model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        prompt_caching = false
+      },
+	},
+  },
+
   -- open chat sidebar on left or right side
   sidebar_position = "left",
   -- can be changed to "telescope"

--- a/lua/magenta/actions.lua
+++ b/lua/magenta/actions.lua
@@ -59,13 +59,7 @@ M.pick_context_files = function()
 end
 
 M.pick_provider = function()
-  local items = {
-    'anthropic claude-3-7-sonnet-latest',
-    'anthropic claude-3-5-sonnet-latest',
-    'openai gpt-4o',
-    'openai o1',
-    'openai o1-mini'
-  }
+  local items = Options.get_model_strings()
   vim.ui.select(items, { prompt = "Select Model", }, function (choice)
     if choice ~= nil then
       vim.cmd("Magenta provider " .. choice )

--- a/lua/magenta/actions.lua
+++ b/lua/magenta/actions.lua
@@ -60,9 +60,15 @@ end
 
 M.pick_provider = function()
   local items = Options.get_model_strings()
-  vim.ui.select(items, { prompt = "Select Model", }, function (choice)
+  local display_items = {}
+  local command_map = {}
+  for _, item in ipairs(items) do
+    table.insert(display_items, item.display)
+    command_map[item.display] = item.command
+  end
+  vim.ui.select(display_items, { prompt = "Select Model", }, function (choice)
     if choice ~= nil then
-      vim.cmd("Magenta provider " .. choice )
+      vim.cmd("Magenta provider " .. command_map[choice])
     end
   end)
 end

--- a/lua/magenta/init.lua
+++ b/lua/magenta/init.lua
@@ -89,7 +89,7 @@ M.bridge = function(channelId)
           end
 
           if parts[2] == "provider" and parts[3] == "openai" and #parts > 3 then
-            local provider_options = {"omitParallelToolCalls"}
+            local provider_options = {"omit_parallel_tool_calls"}
             if ArgLead == '' then
               return provider_options
             end

--- a/lua/magenta/init.lua
+++ b/lua/magenta/init.lua
@@ -89,7 +89,7 @@ M.bridge = function(channelId)
           end
 
           if parts[2] == "provider" and parts[3] == "openai" and #parts > 3 then
-            local provider_options = {"omitParallelToolCalls=true", "omitParallelToolCalls=false"}
+            local provider_options = {"omitParallelToolCalls"}
             if ArgLead == '' then
               return provider_options
             end

--- a/lua/magenta/init.lua
+++ b/lua/magenta/init.lua
@@ -75,17 +75,31 @@ M.bridge = function(channelId)
       nargs = "+",
       range = true,
       desc = "Execute Magenta command",
-      complete = function(ArgLead, CmdLine)
-        local commands = CmdLine:match("^'<,'>") and visual_commands or normal_commands
+        complete = function(ArgLead, CmdLine)
+          local parts = vim.split(CmdLine, "%s+")
+          local commands = CmdLine:match("^'<,'>") and visual_commands or normal_commands
 
-        if ArgLead == '' then
-          return commands
+          if #parts <= 2 then
+            if ArgLead == '' then
+              return commands
+            end
+            return vim.tbl_filter(function(cmd)
+              return cmd:find('^' .. ArgLead)
+            end, commands)
+          end
+
+          if parts[2] == "provider" and parts[3] == "openai" and #parts > 3 then
+            local provider_options = {"omitParallelToolCalls=true", "omitParallelToolCalls=false"}
+            if ArgLead == '' then
+              return provider_options
+            end
+            return vim.tbl_filter(function(opt)
+              return opt:find('^' .. ArgLead)
+            end, provider_options)
+          end
+
+          return {}
         end
-        -- Filter based on ArgLead
-        return vim.tbl_filter(function(cmd)
-          return cmd:find('^' .. ArgLead)
-        end, commands)
-      end
     }
   )
 

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -68,9 +68,9 @@ M.get_model_strings = function()
 			if entry.model then
 				local command_string = provider .. " " .. entry.model
 				if provider == "openai" and entry.omitParallelToolCalls ~= nil then
-					command_string = command_string
-						.. " omitParallelToolCalls="
-						.. (entry.omitParallelToolCalls and "true" or "false")
+					if entry.omitParallelToolCalls then
+						command_string = command_string .. " omitParallelToolCalls"
+					end
 				end
 				local display_string = provider .. " " .. entry.model
 				table.insert(result, {

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -30,8 +30,8 @@ local defaults = {
   models = {
     openai = {
       { model = "gpt-4o" },
-      { model = "o1" },
-      { model = "o1-mini" },
+      { model = "o1", omitParallelToolCalls = true },
+      { model = "o1-mini"}
     },
 	anthropic = {
 	  { model = "claude-3-7-sonnet-latest" },
@@ -66,7 +66,17 @@ M.get_model_strings = function()
 	for provider, entries in pairs(models) do
 		for _, entry in ipairs(entries) do
 			if entry.model then
-				table.insert(result, provider .. " " .. entry.model)
+				local command_string = provider .. " " .. entry.model
+				if provider == "openai" and entry.omitParallelToolCalls ~= nil then
+					command_string = command_string
+						.. " omitParallelToolCalls="
+						.. (entry.omitParallelToolCalls and "true" or "false")
+				end
+				local display_string = provider .. " " .. entry.model
+				table.insert(result, {
+					display = display_string,
+					command = command_string
+				})
 			end
 		end
 	end

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -30,7 +30,7 @@ local defaults = {
   models = {
     openai = {
       { model = "gpt-4o" },
-      { model = "o1", omitParallelToolCalls = true },
+      { model = "o1", omit_parallel_tool_calls = true },
     },
 	anthropic = {
 	  { model = "claude-3-7-sonnet-latest" },
@@ -66,9 +66,9 @@ M.get_model_strings = function()
 		for _, entry in ipairs(entries) do
 			if entry.model then
 				local command_string = provider .. " " .. entry.model
-				if provider == "openai" and entry.omitParallelToolCalls ~= nil then
-					if entry.omitParallelToolCalls then
-						command_string = command_string .. " omitParallelToolCalls"
+				if provider == "openai" and entry.omit_parallel_tool_calls ~= nil then
+					if entry.omit_parallel_tool_calls then
+						command_string = command_string .. " omit_parallel_tool_calls"
 					end
 				end
 				local display_string = provider .. " " .. entry.model

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -26,7 +26,21 @@ local defaults = {
         vim.cmd("Magenta submit-inline-edit " .. target_bufnr)
       end,
     },
-  }
+  },
+  models = {
+    openai = {
+      { model = "gpt-4o" },
+      { model = "o1" },
+      { model = "o1-mini" },
+    },
+	anthropic = {
+	  { model = "claude-3-7-sonnet-latest" },
+	  { model = "claude-3-5-sonnet-latest" },
+	},
+	bedrock = {
+	  { model = "anthropic.claude-3-5-sonnet-20241022-v2:0", prompt_caching = false },
+	},
+  },
 }
 
 M.options = defaults
@@ -44,6 +58,19 @@ M.set_options = function(opts)
       end
     end
   end
+end
+
+M.get_model_strings = function()
+	local result = {}
+	local models = M.options.models or {}
+	for provider, entries in pairs(models) do
+		for _, entry in ipairs(entries) do
+			if entry.model then
+				table.insert(result, provider .. " " .. entry.model)
+			end
+		end
+	end
+	return result
 end
 
 return M

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -80,6 +80,7 @@ M.get_model_strings = function()
 			end
 		end
 	end
+	table.sort(result, function(a, b) return a.display < b.display end)
 	return result
 end
 

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -31,7 +31,6 @@ local defaults = {
     openai = {
       { model = "gpt-4o" },
       { model = "o1", omitParallelToolCalls = true },
-      { model = "o1-mini"}
     },
 	anthropic = {
 	  { model = "claude-3-7-sonnet-latest" },

--- a/node/magenta.spec.ts
+++ b/node/magenta.spec.ts
@@ -104,12 +104,15 @@ Awaiting response ⠁`);
         expect(state.model.providerSetting).toEqual({
           provider: "openai",
           model: "gpt-4o",
+          omitParallelToolCalls: false,
         });
         const winbar = await displayState.inputWindow.getOption("winbar");
         expect(winbar).toBe(`Magenta Input (openai gpt-4o)`);
       }
 
-      await driver.nvim.call("nvim_command", ["Magenta provider openai o1"]);
+      await driver.nvim.call("nvim_command", [
+        "Magenta provider openai o1 omitParallelToolCalls=true",
+      ]);
       {
         const state = driver.magenta.chatApp.getState();
         if (state.status != "running") {
@@ -119,10 +122,84 @@ Awaiting response ⠁`);
         expect(state.model.providerSetting).toEqual({
           provider: "openai",
           model: "o1",
+          omitParallelToolCalls: true,
         });
         const winbar = await displayState.inputWindow.getOption("winbar");
         expect(winbar).toBe(`Magenta Input (openai o1)`);
       }
+    });
+  });
+
+  it("should correctly set omitParallelToolCalls", async () => {
+    await withDriver(async (driver) => {
+      await driver.nvim.call("nvim_command", [
+        "Magenta provider openai o1 omitParallelToolCalls=true",
+      ]);
+      let state = driver.magenta.chatApp.getState();
+      if (state.status != "running") {
+        throw new Error(`Expected state to be running`);
+      }
+      expect(state.model.providerSetting).toEqual({
+        provider: "openai",
+        model: "o1",
+        omitParallelToolCalls: true,
+      });
+
+      await driver.nvim.call("nvim_command", [
+        "Magenta provider openai o1 omitParallelToolCalls=false",
+      ]);
+      state = driver.magenta.chatApp.getState();
+      if (state.status != "running") {
+        throw new Error(`Expected state to be running`);
+      }
+      expect(state.model.providerSetting).toEqual({
+        provider: "openai",
+        model: "o1",
+        omitParallelToolCalls: false,
+      });
+    });
+  });
+
+  it("should correctly set omitParallelToolCalls when switching between two openai models", async () => {
+    await withDriver(async (driver) => {
+      await driver.nvim.call("nvim_command", [
+        "Magenta provider openai gpt-4o",
+      ]);
+      let state = driver.magenta.chatApp.getState();
+      if (state.status != "running") {
+        throw new Error(`Expected state to be running`);
+      }
+      expect(state.model.providerSetting).toEqual({
+        provider: "openai",
+        model: "gpt-4o",
+        omitParallelToolCalls: false,
+      });
+
+      await driver.nvim.call("nvim_command", [
+        "Magenta provider openai o1 omitParallelToolCalls=true",
+      ]);
+      state = driver.magenta.chatApp.getState();
+      if (state.status != "running") {
+        throw new Error(`Expected state to be running`);
+      }
+      expect(state.model.providerSetting).toEqual({
+        provider: "openai",
+        model: "o1",
+        omitParallelToolCalls: true,
+      });
+
+      await driver.nvim.call("nvim_command", [
+        "Magenta provider openai gpt-4o",
+      ]);
+      state = driver.magenta.chatApp.getState();
+      if (state.status != "running") {
+        throw new Error(`Expected state to be running`);
+      }
+      expect(state.model.providerSetting).toEqual({
+        provider: "openai",
+        model: "gpt-4o",
+        omitParallelToolCalls: false,
+      });
     });
   });
 

--- a/node/magenta.spec.ts
+++ b/node/magenta.spec.ts
@@ -111,7 +111,7 @@ Awaiting response ⠁`);
       }
 
       await driver.nvim.call("nvim_command", [
-        "Magenta provider openai o1 omitParallelToolCalls=true",
+        "Magenta provider openai o1 omit_parallel_tool_calls",
       ]);
       {
         const state = driver.magenta.chatApp.getState();
@@ -127,79 +127,6 @@ Awaiting response ⠁`);
         const winbar = await displayState.inputWindow.getOption("winbar");
         expect(winbar).toBe(`Magenta Input (openai o1)`);
       }
-    });
-  });
-
-  it("should correctly set omitParallelToolCalls", async () => {
-    await withDriver(async (driver) => {
-      await driver.nvim.call("nvim_command", [
-        "Magenta provider openai o1 omitParallelToolCalls=true",
-      ]);
-      let state = driver.magenta.chatApp.getState();
-      if (state.status != "running") {
-        throw new Error(`Expected state to be running`);
-      }
-      expect(state.model.providerSetting).toEqual({
-        provider: "openai",
-        model: "o1",
-        omitParallelToolCalls: true,
-      });
-
-      await driver.nvim.call("nvim_command", [
-        "Magenta provider openai o1 omitParallelToolCalls=false",
-      ]);
-      state = driver.magenta.chatApp.getState();
-      if (state.status != "running") {
-        throw new Error(`Expected state to be running`);
-      }
-      expect(state.model.providerSetting).toEqual({
-        provider: "openai",
-        model: "o1",
-        omitParallelToolCalls: false,
-      });
-    });
-  });
-
-  it("should correctly set omitParallelToolCalls when switching between two openai models", async () => {
-    await withDriver(async (driver) => {
-      await driver.nvim.call("nvim_command", [
-        "Magenta provider openai gpt-4o",
-      ]);
-      let state = driver.magenta.chatApp.getState();
-      if (state.status != "running") {
-        throw new Error(`Expected state to be running`);
-      }
-      expect(state.model.providerSetting).toEqual({
-        provider: "openai",
-        model: "gpt-4o",
-        omitParallelToolCalls: false,
-      });
-
-      await driver.nvim.call("nvim_command", [
-        "Magenta provider openai o1 omitParallelToolCalls=true",
-      ]);
-      state = driver.magenta.chatApp.getState();
-      if (state.status != "running") {
-        throw new Error(`Expected state to be running`);
-      }
-      expect(state.model.providerSetting).toEqual({
-        provider: "openai",
-        model: "o1",
-        omitParallelToolCalls: true,
-      });
-
-      await driver.nvim.call("nvim_command", [
-        "Magenta provider openai gpt-4o",
-      ]);
-      state = driver.magenta.chatApp.getState();
-      if (state.status != "running") {
-        throw new Error(`Expected state to be running`);
-      }
-      expect(state.model.providerSetting).toEqual({
-        provider: "openai",
-        model: "gpt-4o",
-        omitParallelToolCalls: false,
-      });
     });
   });
 

--- a/node/magenta.ts
+++ b/node/magenta.ts
@@ -79,11 +79,10 @@ export class Magenta {
         const [providerName, model, ...optionalArgs] = rest;
         const provider = providerName as ProviderName;
 
-        let omitParallelToolCalls = this.options.openai.omitParallelToolCalls;
+        let omitParallelToolCalls = false;
         for (const arg of optionalArgs) {
-          const match = arg.match(/^omitParallelToolCalls=(true|false)$/i);
-          if (match) {
-            omitParallelToolCalls = match[1].toLowerCase() === "true";
+          if (arg === "omitParallelToolCalls") {
+            omitParallelToolCalls = true;
           }
         }
 

--- a/node/magenta.ts
+++ b/node/magenta.ts
@@ -79,10 +79,10 @@ export class Magenta {
         const [providerName, model, ...optionalArgs] = rest;
         const provider = providerName as ProviderName;
 
-        let omitParallelToolCalls = false;
+        let omit_parallel_tool_calls = false;
         for (const arg of optionalArgs) {
-          if (arg === "omitParallelToolCalls") {
-            omitParallelToolCalls = true;
+          if (arg === "omit_parallel_tool_calls") {
+            omit_parallel_tool_calls = true;
           }
         }
 
@@ -97,8 +97,8 @@ export class Magenta {
             provider,
             model: model || this.options[provider].model,
             omitParallelToolCalls:
-              omitParallelToolCalls !== undefined
-                ? omitParallelToolCalls
+              omit_parallel_tool_calls !== undefined
+                ? omit_parallel_tool_calls
                 : false,
           };
         } else {

--- a/node/options.ts
+++ b/node/options.ts
@@ -2,7 +2,7 @@ import { PROVIDER_NAMES, type ProviderName } from "./providers/provider";
 
 export type MagentaOptions = {
   provider: ProviderName;
-  openai: { model: string };
+  openai: { model: string; omitParallelToolCalls?: boolean };
   anthropic: { model: string };
   bedrock: { model: string; promptCaching: boolean };
   sidebarPosition: "left" | "right";
@@ -54,6 +54,10 @@ export function parseOptions(inputOptions: unknown): MagentaOptions {
       };
       if (typeof openaiOptions["model"] == "string") {
         options.openai.model = openaiOptions.model;
+      }
+      if (typeof openaiOptions["omitParallelToolCalls"] == "boolean") {
+        options.openai.omitParallelToolCalls =
+          openaiOptions.omitParallelToolCalls;
       }
     }
 

--- a/node/providers/openai.spec.ts
+++ b/node/providers/openai.spec.ts
@@ -81,7 +81,7 @@ describe("openai.ts", () => {
       });
 
       await driver.nvim.call("nvim_command", [
-        "Magenta provider openai o1 omitParallelToolCalls=true",
+        "Magenta provider openai o1 omit_parallel_tool_calls",
       ]);
       state = driver.magenta.chatApp.getState();
       if (state.status != "running") {

--- a/node/providers/openai.spec.ts
+++ b/node/providers/openai.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { OpenAIProvider } from "./openai.ts";
+import type { Nvim } from "nvim-node";
+import type { ProviderMessage } from "./provider-types.ts";
+import { withDriver } from "../test/preamble.ts";
+
+vi.mock("openai", () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: vi.fn(),
+        },
+      },
+    })),
+  };
+});
+
+describe("openai.ts", () => {
+  let mockNvim: Nvim;
+  let messages: ProviderMessage[];
+
+  beforeEach(() => {
+    mockNvim = { logger: { debug: vi.fn() } } as unknown as Nvim;
+    process.env.OPENAI_API_KEY = "test-key";
+
+    messages = [
+      {
+        role: "user",
+        content: "Hello world",
+      },
+    ];
+  });
+
+  it("should set parallel_tool_calls to false when omitParallelToolCalls is false", () => {
+    const provider = new OpenAIProvider(mockNvim, {
+      model: "gpt-4",
+      omitParallelToolCalls: false,
+    });
+
+    const params = provider.createStreamParameters(messages);
+
+    expect(params.parallel_tool_calls).toBe(false);
+  });
+
+  it("should not include parallel_tool_calls when omitParallelToolCalls is true", () => {
+    const provider = new OpenAIProvider(mockNvim, {
+      model: "gpt-4",
+      omitParallelToolCalls: true,
+    });
+
+    const params = provider.createStreamParameters(messages);
+
+    expect(params.parallel_tool_calls).toBeUndefined();
+  });
+
+  it("paralell_tool_calls should be included by default and set to false", () => {
+    const provider = new OpenAIProvider(mockNvim, {
+      model: "gpt-4",
+    });
+
+    const params = provider.createStreamParameters(messages);
+
+    expect(params).toHaveProperty("parallel_tool_calls");
+    expect(params.parallel_tool_calls).toBe(false);
+  });
+
+  it("should correctly set parallel_tool_calls when switching between two openai models", async () => {
+    await withDriver(async (driver) => {
+      await driver.nvim.call("nvim_command", [
+        "Magenta provider openai gpt-4o",
+      ]);
+      let state = driver.magenta.chatApp.getState();
+      if (state.status != "running") {
+        throw new Error(`Expected state to be running`);
+      }
+      expect(state.model.providerSetting).toEqual({
+        provider: "openai",
+        model: "gpt-4o",
+        omitParallelToolCalls: false,
+      });
+
+      await driver.nvim.call("nvim_command", [
+        "Magenta provider openai o1 omitParallelToolCalls=true",
+      ]);
+      state = driver.magenta.chatApp.getState();
+      if (state.status != "running") {
+        throw new Error(`Expected state to be running`);
+      }
+      expect(state.model.providerSetting).toEqual({
+        provider: "openai",
+        model: "o1",
+        omitParallelToolCalls: true,
+      });
+    });
+  });
+});

--- a/node/providers/openai.ts
+++ b/node/providers/openai.ts
@@ -18,7 +18,6 @@ import * as ReplaceSelection from "../inline-edit/replace-selection-tool.ts";
 
 export type OpenAIOptions = {
   model: string;
-  /* If true, provider passes `parallel_tool_calls: false` */
   omitParallelToolCalls?: boolean;
 };
 
@@ -203,7 +202,7 @@ export class OpenAIProvider implements Provider {
 
     // see https://platform.openai.com/docs/guides/function-calling#parallel-function-calling-and-structured-outputs
     // this recommends disabling parallel tool calls when strict adherence to schema is needed
-    // However, some models (like o1), error out when `parallel_tool_calls` is passed.
+    // However, some models (like o1) error out when `parallel_tool_calls` is passed.
     if (!this.omitParallelToolCalls) {
       params.parallel_tool_calls = false;
     }

--- a/node/providers/provider-types.ts
+++ b/node/providers/provider-types.ts
@@ -7,7 +7,7 @@ import type { Result } from "../utils/result";
 export const PROVIDER_NAMES = ["anthropic", "openai", "bedrock"] as const;
 export type ProviderSetting =
   | { provider: "anthropic"; model: string }
-  | { provider: "openai"; model: string }
+  | { provider: "openai"; model: string; omitParallelToolCalls?: boolean }
   | { provider: "bedrock"; model: string; promptCaching: boolean };
 export type ProviderName = ProviderSetting["provider"];
 
@@ -61,6 +61,7 @@ export interface Provider {
   setModel(model: string): void;
   createStreamParameters(messages: Array<ProviderMessage>): unknown;
   countTokens(messages: Array<ProviderMessage>): Promise<number>;
+  setOmitParallelToolCalls?(omit: boolean): void;
 
   inlineEdit(messages: Array<ProviderMessage>): Promise<{
     inlineEdit: Result<InlineEditToolRequest, { rawRequest: unknown }>;

--- a/node/providers/provider.ts
+++ b/node/providers/provider.ts
@@ -24,7 +24,10 @@ export function getProvider(
         clients[providerSetting.provider] = new AnthropicProvider(nvim);
         break;
       case "openai":
-        clients[providerSetting.provider] = new OpenAIProvider(nvim);
+        clients[providerSetting.provider] = new OpenAIProvider(nvim, {
+          model: providerSetting.model,
+          omitParallelToolCalls: providerSetting.omitParallelToolCalls ?? false,
+        });
         break;
       case "bedrock":
         clients[providerSetting.provider] = new BedrockProvider(
@@ -39,6 +42,15 @@ export function getProvider(
 
   const provider = clients[providerSetting.provider]!;
   provider.setModel(providerSetting.model);
+
+  if (
+    providerSetting.provider === "openai" &&
+    "setOmitParallelToolCalls" in provider
+  ) {
+    provider.setOmitParallelToolCalls(
+      providerSetting.omitParallelToolCalls ?? false,
+    );
+  }
 
   return provider;
 }


### PR DESCRIPTION
## Overview
Adds support for defining the models users can select with  `<leader>mp` from the plugin's config. 

Also, adds support for OpenAI's o1 by optionally omitting the `parallel_tool_calls` param from the OpenAI request; o1 does not support this parameter. 

## User-Defined Models List

Currently, users can choose between models hardcoded in [actions.lua](https://github.com/dlants/magenta.nvim/blob/main/lua/magenta/actions.lua). Although different models can be selected manually with `:Magenta provider`, this change makes this more intuitive. Users can now optionally define the models listed for each provider in their plugin config. For a given provider, the specified models will be the options for that provider; otherwise, if a provider is not specified, it will display the default models for that provider.

```
models = {
  openai = {
    { model = "gpt-4o-mini" },
  },
}
```
The above redefines the options for openai. The resulting provider/model dialog looks like this:
![model picker](https://github.com/user-attachments/assets/2cd3ee63-0595-47a6-992b-f15ba60745b0)

This change also lets you hide providers. Here, I modify the previous config to hide `bedrock`:
```
models = {
  openai = {
    { model = "gpt-4o-mini" },
  },
  bedrock = {}
}
```
Now, my dialog looks like this:
![no bedrock](https://github.com/user-attachments/assets/081ff015-141a-4c9c-ac5d-19a7673e2bce)

### Approach
To implement this, I added the `get_model_strings` method in `options.lua` which flattens the `models` in the plugin's config into strings which are displayed in the models/providers dialog and passed to the `:Magenta provider` command. This replaces the existing hardcoded `items` in [actions.lua](https://github.com/dlants/magenta.nvim/blob/cb2a2acd006cb98378574a7932d6eee3c179bb0d/lua/magenta/actions.lua)

A separate `models` table was added to make this change backwards compatible. I think a cleaner approach might be to add a "default" option that can be set for a given model per provider, but that would break existing users' configs.


## o1 Support
This PR also adds support for OpenAI's o1 by allowing users to omit the parameter `parallel_tool_calls` from the openai request. 

### Problem
After `:Magenta provider openai o1`, a 400 error is returned with the message: "Unsupported parameter: 'parallel_tool_calls' is not supported with this model". [this post](https://github.com/langchain-ai/langchain/issues/25357) indicates one solution is to simply omit the param which I found to work.

### Solution
This PR makes it possible to omit this parameter by providing the optional `omit_parallel_tool_calls` argument to `:Magenta provider`:

```
:Magenta provider openai o1 omit_parallel_tool_calls
```

Expanding on the above config work, this can be set for each openai model in the plugin config:

```
models = {
  openai = {
    {
      model = "o1", 
      omit_parallel_tool_calls = true
    },
  },
}
```

### Approach
I implemented the `omit_parallel_tool_calls` option by adding it as a flag to the existing `:Magenta provider` command instead of sending complex configuration data to the backend. This keeps things simple and works with how users already select models. `omit_parallel_tool_calls` is `false` by default.

### Testing
This PR introduces new tests to cover the `omitParallelToolCalls` functionality:
- Checks whether setting `omitParallelToolCalls` correctly sets the `parallel_tool_calls` parameter in the openai request
- Checks whether the `:Magenta provider` command flag `omit_parallel_tool_calls` correctly sets the value of `omitParallelToolCalls` in the TypeScript.

## General Notes
- The README's default config section has also been updated to reflect these changes.
