### PR TITLE
Add support for the 'snacks' picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ require('magenta').setup({
   },
   -- open chat sidebar on left or right side
   sidebar_position = "left",
-  -- can be changed to "telescope"
+  -- can be changed to "telescope" or "snacks"
   picker = "fzf-lua",
   -- enable default keymaps shown below
   default_keymaps = true,

--- a/lua/magenta/actions.lua
+++ b/lua/magenta/actions.lua
@@ -47,14 +47,45 @@ local telescope_files = function()
   })
 end
 
+local snacks_files = function()
+  local snacks = require("snacks")
+
+  local completed = false
+  snacks.picker.pick({
+    source = "files",
+    title = "Select context files for Magenta",
+    confirm = function(picker)
+      if completed then return end
+      completed = true
+      local items = picker:selected({ fallback = true })
+
+      if #items > 0 then
+        local escaped_files = {}
+        for _, item in ipairs(items) do
+          table.insert(escaped_files, vim.fn.shellescape(item.file))
+        end
+        vim.cmd("Magenta context-files " .. table.concat(escaped_files, " "))
+      end
+
+      picker:close()
+    end,
+    on_close = function()
+      if completed then return end
+      completed = true
+    end,
+  })
+end
+
 
 M.pick_context_files = function()
   if Options.options.picker == "fzf-lua" then
     fzf_files()
   elseif Options.options.picker == "telescope" then
     telescope_files()
+  elseif Options.options.picker == "snacks" then
+    snacks_files()
   else
-    vim.notify("Neither fzf-lua nor telescope are installed!", vim.log.levels.ERROR)
+    vim.notify("No supported picker (fzf-lua, telescope, or snacks) installed!", vim.log.levels.ERROR)
   end
 end
 

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -36,14 +36,13 @@ M.options = defaults
 
 M.set_options = function(opts)
   M.options = vim.tbl_deep_extend("force", defaults, opts or {})
-  if (opts.picker == nil) then
-    local success, _ = pcall(require, "fzf-lua")
-    if success then
-      M.options.picker = "fzf-lua"
-    else
-      success, _ = pcall(require, "telescope")
+  if opts.picker == nil then
+    local pickers = { "fzf-lua", "telescope", "snacks" }
+    for _, picker in ipairs(pickers) do
+      local success, _ = pcall(require, picker)
       if success then
-        M.options.picker = "telescope"
+        M.options.picker = picker
+        break
       end
     end
   end


### PR DESCRIPTION
Snacks are an increasingly popular set of plugins by Folke. The Snacks picker is widely used nowadays. This PR implements support for it in magenta.nvim:

https://github.com/folke/snacks.nvim