### PR TITLE
Fix bash_command for openai

### DIFF
--- a/node/tools/bashCommand.ts
+++ b/node/tools/bashCommand.ts
@@ -27,6 +27,7 @@ You should not run commands that do not halt, such as \`docker compose up\` with
       },
     },
     required: ["command"],
+    additionalProperties: false,
   },
 };
 


### PR DESCRIPTION
Without this I get an error from the openai API that `additionalProperties` must be passed and set to false. This aligns the BashCommand tool with the rest of the tools.

Unfortunately I don't think there's anywhere in the type that gets passed to the openai call that requires this set, it just seems to be enforced on the backend.