### PR TITLE
refactor to controller arch

### DIFF
--- a/node/chat/chat.ts
+++ b/node/chat/chat.ts
@@ -1,0 +1,149 @@
+import type { Nvim } from "nvim-node";
+import type { MagentaOptions, Profile } from "../options";
+import type { RootMsg } from "../root-msg";
+import type { Dispatch } from "../tea/tea";
+import { Thread, view as threadView } from "./thread";
+import type { Lsp } from "../lsp";
+import { assertUnreachable } from "../utils/assertUnreachable";
+import { d } from "../tea/view";
+import { ContextManager } from "../context/context-manager";
+
+type State =
+  | {
+      state: "pending";
+    }
+  | {
+      state: "initialized";
+      thread: Thread;
+    }
+  | {
+      state: "error";
+      error: Error;
+    };
+
+type Msg =
+  | {
+      type: "thread-initialized";
+      thread: Thread;
+    }
+  | {
+      type: "thread-error";
+      error: Error;
+    };
+
+export type ChatMsg = {
+  type: "chat-msg";
+  msg: Msg;
+};
+
+export class Chat {
+  state: State;
+
+  constructor(
+    private context: {
+      dispatch: Dispatch<RootMsg>;
+      options: MagentaOptions;
+      nvim: Nvim;
+      lsp: Lsp;
+    },
+  ) {
+    this.state = {
+      state: "pending",
+    };
+
+    this.initThread().catch((e: Error) => {
+      this.context.dispatch({
+        type: "chat-msg",
+        msg: {
+          type: "thread-error",
+          error: e,
+        },
+      });
+    });
+  }
+
+  update(msg: RootMsg) {
+    if (msg.type == "chat-msg") {
+      switch (msg.msg.type) {
+        case "thread-initialized":
+          this.state = {
+            state: "initialized",
+            thread: msg.msg.thread,
+          };
+          return;
+
+        case "thread-error":
+          this.state = {
+            state: "error",
+            error: msg.msg.error,
+          };
+          return;
+        default:
+          assertUnreachable(msg.msg);
+      }
+    }
+
+    if (this.state.state == "initialized") {
+      this.state.thread.update(msg);
+    }
+  }
+
+  async getMessages() {
+    if (this.state.state == "initialized") {
+      return await this.state.thread.getMessages();
+    }
+    return [];
+  }
+
+  async initThread() {
+    const contextManager = await ContextManager.create({
+      dispatch: this.context.dispatch,
+      nvim: this.context.nvim,
+      options: this.context.options,
+    });
+
+    const thread = new Thread({
+      dispatch: this.context.dispatch,
+      contextManager,
+      profile: getActiveProfile(
+        this.context.options.profiles,
+        this.context.options.activeProfile,
+      ),
+      nvim: this.context.nvim,
+      lsp: this.context.lsp,
+      options: this.context.options,
+    });
+
+    this.context.dispatch({
+      type: "chat-msg",
+      msg: {
+        type: "thread-initialized",
+        thread,
+      },
+    });
+  }
+
+  view() {
+    switch (this.state.state) {
+      case "pending":
+        return d`Initializing...`;
+      case "initialized":
+        return threadView({
+          thread: this.state.thread,
+          dispatch: (msg) => this.context.dispatch({ type: "thread-msg", msg }),
+        });
+      case "error":
+        return d`Error: ${this.state.error.message}`;
+      default:
+        assertUnreachable(this.state);
+    }
+  }
+}
+
+function getActiveProfile(profiles: Profile[], activeProfile: string) {
+  const profile = profiles.find((p) => p.name == activeProfile);
+  if (!profile) {
+    throw new Error(`Profile ${activeProfile} not found.`);
+  }
+  return profile;
+}

--- a/node/chat/message.spec.ts
+++ b/node/chat/message.spec.ts
@@ -20,7 +20,7 @@ describe("node/chat/message.spec.ts", () => {
             status: "ok",
             value: {
               id: "id1" as ToolRequestId,
-              name: "replace",
+              toolName: "replace",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 find: `Moonlight whispers through the trees,\nSilver shadows dance with ease.`,
@@ -32,7 +32,7 @@ describe("node/chat/message.spec.ts", () => {
             status: "ok",
             value: {
               id: "id2" as ToolRequestId,
-              name: "replace",
+              toolName: "replace",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 find: `Stars above like diamonds bright,\nPaint their stories in the night.`,

--- a/node/chat/part.ts
+++ b/node/chat/part.ts
@@ -1,8 +1,4 @@
-import {
-  ToolManager,
-  type Msg as ToolManagerMsg,
-  type ToolRequestId,
-} from "../tools/toolManager.ts";
+import { ToolManager, type ToolRequestId } from "../tools/toolManager.ts";
 import { assertUnreachable } from "../utils/assertUnreachable.ts";
 import { d, type View } from "../tea/view.ts";
 import type {
@@ -11,7 +7,6 @@ import type {
   StopReason,
   Usage,
 } from "../providers/provider.ts";
-import { wrapThunk, type Dispatch, type Thunk } from "../tea/tea.ts";
 
 type State =
   | {
@@ -33,11 +28,6 @@ type State =
       usage: Usage;
     };
 
-export type Msg = {
-  type: "tool-manager-msg";
-  msg: ToolManagerMsg;
-};
-
 export class Part {
   toolManager: ToolManager;
   state: State;
@@ -51,17 +41,6 @@ export class Part {
   }) {
     this.state = state;
     this.toolManager = toolManager;
-  }
-
-  update(msg: Msg): Thunk<Msg> | undefined {
-    switch (msg.type) {
-      case "tool-manager-msg": {
-        const thunk = this.toolManager.update(msg.msg);
-        return wrapThunk("tool-manager-msg", thunk);
-      }
-      default:
-        return assertUnreachable(msg.type);
-    }
   }
 
   toMessageContent(): {
@@ -105,8 +84,7 @@ export class Part {
 
 export const view: View<{
   part: Part;
-  dispatch: Dispatch<Msg>;
-}> = ({ part, dispatch }) => {
+}> = ({ part }) => {
   switch (part.state.type) {
     case "text":
       return d`${part.state.text}`;
@@ -123,12 +101,7 @@ ${JSON.stringify(part.state.rawRequest, null, 2) || "undefined"}`;
           `Unable to find model with requestId ${part.state.requestId}`,
         );
       }
-      return part.toolManager.renderTool(toolWrapper, (msg) =>
-        dispatch({
-          type: "tool-manager-msg",
-          msg,
-        }),
-      );
+      return part.toolManager.renderTool(toolWrapper);
     }
 
     case "stop-msg": {

--- a/node/chat/thread.spec.ts
+++ b/node/chat/thread.spec.ts
@@ -22,7 +22,7 @@ describe("node/chat/thread.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "list_buffers",
+              toolName: "list_buffers",
               input: {},
             },
           },
@@ -89,7 +89,7 @@ describe("node/chat/thread.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId1,
-              name: "list_directory",
+              toolName: "list_directory",
               input: { dirPath: "." },
             },
           },
@@ -107,7 +107,7 @@ describe("node/chat/thread.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId2,
-              name: "list_buffers",
+              toolName: "list_buffers",
               input: {},
             },
           },
@@ -167,7 +167,7 @@ describe("node/chat/thread.spec.ts", () => {
         );
 
         if (toolUseContent && toolUseContent.request) {
-          expect(toolUseContent.request.name).toBe("list_directory");
+          expect(toolUseContent.request.toolName).toBe("list_directory");
         }
       }
 

--- a/node/chat/thread.spec.ts
+++ b/node/chat/thread.spec.ts
@@ -137,7 +137,11 @@ describe("node/chat/thread.spec.ts", () => {
       );
 
       // Verify the thread's internal message structure is correct
-      const messages = await driver.magenta.thread.getMessages();
+      const state = driver.magenta.chat.state;
+      if (state.state != "initialized") {
+        throw new Error(`expected thread to be initialized`);
+      }
+      const messages = await state.thread.getMessages();
 
       // Check that there are 6 messages (user, assistant, user with tool result,
       // assistant, user with tool result, assistant)

--- a/node/context/context-manager.spec.ts
+++ b/node/context/context-manager.spec.ts
@@ -16,6 +16,7 @@ describe("context-manager.spec.ts", () => {
         await driver.showSidebar();
 
         // Add file to context using the context-files command
+        console.log(`context-files command`);
         await driver.nvim.call("nvim_command", [
           `Magenta context-files '${testFilePath}'`,
         ]);

--- a/node/context/context-manager.ts
+++ b/node/context/context-manager.ts
@@ -84,7 +84,6 @@ export class ContextManager {
         delete this.files[msg.absFilePath];
         return undefined;
       case "open-file":
-        console.log(`open-file dispatch`);
         return () => {
           return this.openFileInWindow(msg.absFilePath);
         };
@@ -273,7 +272,6 @@ ${content}
   }
 
   async openFileInWindow(absFilePath: string): Promise<void> {
-    console.log(`openFileInWindow ${absFilePath}`);
     try {
       const windows = await getAllWindows(this.nvim);
       const nonMagentaWindows = [];

--- a/node/context/context-manager.ts
+++ b/node/context/context-manager.ts
@@ -12,7 +12,13 @@ import { getcwd, getAllWindows } from "../nvim/nvim";
 import { NvimBuffer } from "../nvim/buffer";
 import type { WindowId } from "../nvim/window";
 import { WIDTH } from "../sidebar";
-import type { Dispatch, Thunk } from "../tea/tea";
+import type { Dispatch } from "../tea/tea";
+import type { RootMsg } from "../root-msg";
+
+export type ContextManagerMsg = {
+  type: "context-manager-msg";
+  msg: Msg;
+};
 
 export type Msg =
   | {
@@ -31,6 +37,8 @@ export type Msg =
     };
 
 export class ContextManager {
+  public dispatch: Dispatch<RootMsg>;
+  public myDispatch: Dispatch<Msg>;
   public files: {
     [absFilePath: string]: {
       relFilePath: string;
@@ -42,10 +50,12 @@ export class ContextManager {
   private options: MagentaOptions;
 
   private constructor({
+    dispatch,
     nvim,
     options,
     initialFiles = {},
   }: {
+    dispatch: Dispatch<RootMsg>;
     nvim: Nvim;
     options: MagentaOptions;
     initialFiles?: {
@@ -55,6 +65,9 @@ export class ContextManager {
       };
     };
   }) {
+    this.dispatch = dispatch;
+    this.myDispatch = (msg) =>
+      this.dispatch({ type: "context-manager-msg", msg });
     this.nvim = nvim;
     this.options = options;
     this.bufferAndFileManager = new BufferAndFileManager(nvim);
@@ -62,17 +75,19 @@ export class ContextManager {
   }
 
   static async create({
+    dispatch,
     nvim,
     options,
   }: {
+    dispatch: Dispatch<RootMsg>;
     nvim: Nvim;
     options: MagentaOptions;
   }): Promise<ContextManager> {
     const initialFiles = await ContextManager.loadAutoContext(nvim, options);
-    return new ContextManager({ nvim, options, initialFiles });
+    return new ContextManager({ dispatch, nvim, options, initialFiles });
   }
 
-  update(msg: Msg): Thunk<Msg> | undefined {
+  update(msg: Msg): void {
     switch (msg.type) {
       case "add-file-context":
         this.files[msg.absFilePath] = {
@@ -84,7 +99,11 @@ export class ContextManager {
         delete this.files[msg.absFilePath];
         return undefined;
       case "open-file":
-        return () => this.openFileInWindow(msg.absFilePath);
+        this.openFileInWindow(msg.absFilePath).catch((e: Error) =>
+          this.nvim.logger?.error(e.message),
+        );
+
+        return;
       default:
         assertUnreachable(msg);
     }
@@ -349,17 +368,17 @@ ${content}
     }
   }
 
-  view(dispatch: Dispatch<Msg>) {
+  view() {
     const fileContext = [];
     for (const absFilePath in this.files) {
       fileContext.push(
         withBindings(d`file: \`${this.files[absFilePath].relFilePath}\`\n`, {
           d: () =>
-            dispatch({
+            this.myDispatch({
               type: "remove-file-context",
               absFilePath,
             }),
-          "<CR>": () => dispatch({ type: "open-file", absFilePath }),
+          "<CR>": () => this.myDispatch({ type: "open-file", absFilePath }),
         }),
       );
     }

--- a/node/magenta.spec.ts
+++ b/node/magenta.spec.ts
@@ -76,12 +76,12 @@ Awaiting response ⠁`);
   it("can switch profiles", async () => {
     await withDriver({}, async (driver) => {
       {
-        const state = driver.magenta.chatApp.getState();
-        if (state.status != "running") {
-          throw new Error(`Expected state to be running`);
+        const state = driver.magenta.chat.state;
+        if (state.state != "initialized") {
+          throw new Error(`Expected thread to be initialized`);
         }
 
-        expect(state.model.thread.state.profile).toEqual({
+        expect(state.thread.state.profile).toEqual({
           name: "claude-3-7",
           provider: "anthropic",
           model: "claude-3-7-sonnet-latest",
@@ -96,12 +96,12 @@ Awaiting response ⠁`);
       }
       await driver.nvim.call("nvim_command", ["Magenta profile gpt-4o"]);
       {
-        const state = driver.magenta.chatApp.getState();
-        if (state.status != "running") {
+        const state = driver.magenta.chat.state;
+        if (state.state != "initialized") {
           throw new Error(`Expected state to be running`);
         }
 
-        expect(state.model.thread.state.profile).toEqual({
+        expect(state.thread.state.profile).toEqual({
           name: "gpt-4o",
           provider: "openai",
           model: "gpt-4o",

--- a/node/magenta.ts
+++ b/node/magenta.ts
@@ -1,9 +1,4 @@
 import { Sidebar } from "./sidebar.ts";
-import {
-  Thread,
-  view as threadView,
-  type Msg as ThreadMsg,
-} from "./chat/thread.ts";
 import * as TEA from "./tea/tea.ts";
 import { BINDING_KEYS, type BindingKey } from "./tea/bindings.ts";
 import { pos } from "./tea/view.ts";
@@ -17,6 +12,10 @@ import { pos1col1to0 } from "./nvim/window.ts";
 import { getMarkdownExt } from "./utils/markdown.ts";
 import { parseOptions, type MagentaOptions, type Profile } from "./options.ts";
 import { InlineEditManager } from "./inline-edit/inline-edit-manager.ts";
+import type { RootMsg } from "./root-msg.ts";
+import { Chat } from "./chat/chat.ts";
+import type { Dispatch } from "./tea/tea.ts";
+import type { MessageId } from "./chat/message.ts";
 
 // these constants should match lua/magenta/init.lua
 const MAGENTA_COMMAND = "magentaCommand";
@@ -26,23 +25,21 @@ const MAGENTA_LSP_RESPONSE = "magentaLspResponse";
 
 export class Magenta {
   public sidebar: Sidebar;
-  public chatApp: TEA.App<ThreadMsg, { thread: Thread }>;
+  public chatApp: TEA.App<Chat>;
   public mountedChatApp: TEA.MountedApp | undefined;
   public inlineEditManager: InlineEditManager;
+  public chat: Chat;
+  public dispatch: Dispatch<RootMsg>;
 
   constructor(
     public nvim: Nvim,
     public lsp: Lsp,
     public options: MagentaOptions,
-    public thread: Thread,
   ) {
-    this.sidebar = new Sidebar(this.nvim, this.getActiveProfile());
+    this.dispatch = (msg: RootMsg) => {
+      try {
+        this.chat.update(msg);
 
-    this.chatApp = TEA.createApp({
-      nvim: this.nvim,
-      initialModel: { thread },
-      update: (msg) => {
-        const thunk = this.thread.update(msg);
         if (msg.type == "sidebar-setup-resubmit") {
           if (
             this.sidebar &&
@@ -62,10 +59,27 @@ export class Magenta {
               });
           }
         }
+        if (this.mountedChatApp) {
+          this.mountedChatApp.render();
+        }
+      } catch (e) {
+        nvim.logger?.error(e as Error);
+      }
+    };
 
-        return [{ thread: this.thread }, thunk];
-      },
-      View: threadView,
+    this.chat = new Chat({
+      dispatch: this.dispatch,
+      nvim: this.nvim,
+      options: this.options,
+      lsp: this.lsp,
+    });
+
+    this.sidebar = new Sidebar(this.nvim, this.getActiveProfile());
+
+    this.chatApp = TEA.createApp<Chat>({
+      nvim: this.nvim,
+      initialModel: this.chat,
+      View: () => this.chat.view(),
     });
 
     this.inlineEditManager = new InlineEditManager({ nvim });
@@ -88,9 +102,12 @@ export class Magenta {
         if (profile) {
           this.options.activeProfile = profile.name;
 
-          this.chatApp.dispatch({
-            type: "update-profile",
-            profile: this.getActiveProfile(),
+          this.dispatch({
+            type: "thread-msg",
+            msg: {
+              type: "update-profile",
+              profile: this.getActiveProfile(),
+            },
           });
           await this.sidebar.updateProfile(this.getActiveProfile());
         } else {
@@ -102,6 +119,13 @@ export class Magenta {
       }
 
       case "context-files": {
+        if (this.chat.state.state !== "initialized") {
+          return;
+        }
+        const messages = this.chat.state.thread.state.messages;
+        const message = messages[messages.length - 1];
+        const messageId = message?.state.id || (0 as MessageId);
+
         const parts = input.trim().match(/[^\s']+|'([^']*)'|\S+/g) || [];
         const paths = parts
           .slice(1)
@@ -120,10 +144,14 @@ export class Magenta {
             relFilePath = filePath;
           }
 
-          this.chatApp.dispatch({
-            type: "add-file-context",
-            absFilePath,
-            relFilePath,
+          this.dispatch({
+            type: "context-manager-msg",
+            msg: {
+              type: "add-file-context",
+              absFilePath,
+              relFilePath,
+              messageId,
+            },
           });
         }
 
@@ -149,14 +177,20 @@ export class Magenta {
         this.nvim.logger?.debug(`current message: ${message}`);
         if (!message) return;
 
-        this.chatApp.dispatch({
-          type: "add-message",
-          role: "user",
-          content: message,
+        this.dispatch({
+          type: "thread-msg",
+          msg: {
+            type: "add-message",
+            role: "user",
+            content: message,
+          },
         });
 
-        this.chatApp.dispatch({
-          type: "send-message",
+        this.dispatch({
+          type: "thread-msg",
+          msg: {
+            type: "send-message",
+          },
         });
 
         if (this.mountedChatApp) {
@@ -168,9 +202,12 @@ export class Magenta {
       }
 
       case "clear":
-        this.chatApp.dispatch({
-          type: "clear",
-          profile: this.getActiveProfile(),
+        this.dispatch({
+          type: "thread-msg",
+          msg: {
+            type: "clear",
+            profile: this.getActiveProfile(),
+          },
         });
         break;
 
@@ -260,7 +297,7 @@ ${lines.join("\n")}
 
         const provider = getProvider(this.nvim, this.getActiveProfile());
 
-        const messages = await this.thread.getMessages();
+        const messages = await this.chat.getMessages();
         await this.inlineEditManager.submitInlineEdit(
           bufnr,
           provider,
@@ -350,16 +387,7 @@ ${lines.join("\n")}
     ]);
 
     const parsedOptions = parseOptions(opts);
-    const thread = await Thread.create({
-      profile: getActiveProfile(
-        parsedOptions.profiles,
-        parsedOptions.activeProfile,
-      ),
-      nvim,
-      lsp,
-      options: parsedOptions,
-    });
-    const magenta = new Magenta(nvim, lsp, parsedOptions, thread);
+    const magenta = new Magenta(nvim, lsp, parsedOptions);
     nvim.logger?.info(`Magenta initialized. ${JSON.stringify(parsedOptions)}`);
     return magenta;
   }

--- a/node/providers/anthropic.ts
+++ b/node/providers/anthropic.ts
@@ -101,7 +101,7 @@ export class AnthropicProvider implements Provider {
               return {
                 id: c.request.id,
                 input: c.request.input,
-                name: c.request.name,
+                name: c.request.toolName,
                 type: "tool_use",
               };
             case "tool_result":
@@ -553,10 +553,10 @@ export class AnthropicProvider implements Provider {
               return {
                 status: "ok",
                 value: {
-                  name: name as ToolManager.ToolRequest["name"],
-                  id: req2.id as unknown as ToolRequestId,
+                  toolName: name,
+                  id: req2.id,
                   input: input.value,
-                },
+                } as ToolManager.ToolRequest,
               };
             } else {
               return input;

--- a/node/providers/openai.ts
+++ b/node/providers/openai.ts
@@ -8,7 +8,7 @@ import type {
   Usage,
 } from "./provider-types.ts";
 import { assertUnreachable } from "../utils/assertUnreachable.ts";
-import type { ToolName, ToolRequestId } from "../tools/toolManager.ts";
+import type { ToolRequestId } from "../tools/toolManager.ts";
 import type { Nvim } from "nvim-node";
 import type { Stream } from "openai/streaming.mjs";
 import { DEFAULT_SYSTEM_PROMPT } from "./constants.ts";
@@ -76,7 +76,7 @@ export class OpenAIProvider implements Provider {
               totalTokens += enc.encode(content.text).length;
               break;
             case "tool_use":
-              totalTokens += enc.encode(content.request.name).length;
+              totalTokens += enc.encode(content.request.toolName).length;
               totalTokens += enc.encode(
                 JSON.stringify(content.request.input),
               ).length;
@@ -134,7 +134,7 @@ export class OpenAIProvider implements Provider {
                 type: "function",
                 id: content.request.id,
                 function: {
-                  name: content.request.name,
+                  name: content.request.toolName,
                   arguments: JSON.stringify(content.request.input),
                 },
               });
@@ -574,10 +574,10 @@ export class OpenAIProvider implements Provider {
                 return {
                   status: "ok",
                   value: {
-                    name: name as ToolName,
-                    id: req.id as unknown as ToolRequestId,
+                    toolName: name,
+                    id: req.id,
                     input: input.value,
-                  },
+                  } as ToolManager.ToolRequest,
                 };
               } else {
                 return input;

--- a/node/root-msg.ts
+++ b/node/root-msg.ts
@@ -1,0 +1,14 @@
+import type { ToolManagerMsg } from "./tools/toolManager";
+import type { ThreadMsg } from "./chat/thread";
+import type { ChatMsg } from "./chat/chat";
+import type { ContextManagerMsg } from "./context/context-manager";
+
+export type RootMsg =
+  | ToolManagerMsg
+  | ThreadMsg
+  | ChatMsg
+  | ContextManagerMsg
+  | {
+      type: "sidebar-setup-resubmit";
+      lastUserMessage: string;
+    };

--- a/node/tools/bashCommand.spec.ts
+++ b/node/tools/bashCommand.spec.ts
@@ -24,7 +24,7 @@ describe("node/tools/bashCommand.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "bash_command",
+              toolName: "bash_command",
               input: {
                 command: "echo 'Hello from Magenta!'",
               },
@@ -63,7 +63,7 @@ describe("node/tools/bashCommand.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "bash_command",
+              toolName: "bash_command",
               input: {
                 command: "nonexistentcommand",
               },
@@ -102,7 +102,7 @@ describe("node/tools/bashCommand.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "bash_command",
+              toolName: "bash_command",
               input: {
                 command: 'true && echo "hello, world"',
               },
@@ -150,7 +150,7 @@ describe("node/tools/bashCommand.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "bash_command",
+              toolName: "bash_command",
               input: {
                 command: "true && ls -la",
               },
@@ -191,7 +191,7 @@ describe("node/tools/bashCommand.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "bash_command",
+              toolName: "bash_command",
               input: {
                 command: "sleep 30",
               },
@@ -241,7 +241,7 @@ describe("node/tools/bashCommand.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId1,
-              name: "bash_command",
+              toolName: "bash_command",
               input: {
                 command: `true && echo 'tada'`,
               },
@@ -273,7 +273,7 @@ describe("node/tools/bashCommand.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId2,
-              name: "bash_command",
+              toolName: "bash_command",
               input: {
                 command: `true && echo 'tada'`,
               },

--- a/node/tools/bashCommand.ts
+++ b/node/tools/bashCommand.ts
@@ -1,8 +1,8 @@
 import type { Result } from "../utils/result.ts";
+import type { Dispatch, Thunk } from "../tea/tea.ts";
 import type { ProviderToolResultContent } from "../providers/provider.ts";
 import { d, withBindings } from "../tea/view.ts";
 import type { ToolRequest } from "./toolManager.ts";
-import type { Thunk, Dispatch } from "../tea/tea.ts";
 import type { Nvim } from "nvim-node";
 import { spawn } from "child_process";
 import { assertUnreachable } from "../utils/assertUnreachable.ts";
@@ -56,12 +56,6 @@ type State =
       error: string;
     };
 
-export type Model = {
-  type: "bash_command";
-  request: ToolRequest<"bash_command">;
-  state: State;
-};
-
 export type Msg =
   | { type: "stdout"; text: string }
   | { type: "stderr"; text: string }
@@ -84,93 +78,6 @@ export function validateInput(args: { [key: string]: unknown }): Result<Input> {
     value: {
       command: args.command,
     },
-  };
-}
-
-export function displayInput(input: Input): string {
-  return `command: ${input.command}`;
-}
-
-function executeCommandThunk(model: Model): Thunk<Msg> {
-  return (dispatch) => {
-    return new Promise<void>((resolve) => {
-      const timeout = 300000; // 5 minute timeout
-      const { command } = model.request.input;
-
-      let timeoutId: NodeJS.Timeout | null = null;
-      let childProcess: ReturnType<typeof spawn> | null = null;
-
-      try {
-        // Set up timeout
-        timeoutId = setTimeout(() => {
-          if (childProcess) {
-            childProcess.kill();
-          }
-          dispatch({
-            type: "error",
-            error: `Command timed out after ${timeout / 1000} seconds`,
-          });
-        }, timeout);
-
-        childProcess = spawn("bash", ["-c", command], {
-          stdio: "pipe",
-        });
-
-        // Store the child process in the model state
-        if (model.state.state === "processing") {
-          model.state.childProcess = childProcess;
-        }
-
-        // Set up stdout and stderr handlers
-        childProcess.stdout?.on("data", (data: Buffer) => {
-          const text = data.toString();
-          const lines = text.split("\n");
-          for (const line of lines) {
-            if (line.trim()) {
-              dispatch({ type: "stdout", text: line });
-            }
-          }
-        });
-
-        childProcess.stderr?.on("data", (data: Buffer) => {
-          const text = data.toString();
-          const lines = text.split("\n");
-          for (const line of lines) {
-            if (line.trim()) {
-              dispatch({ type: "stderr", text: line });
-            }
-          }
-        });
-
-        childProcess.on("close", (code: number | null) => {
-          if (timeoutId) clearTimeout(timeoutId);
-          dispatch({ type: "exit", code });
-          resolve();
-        });
-      } catch (error) {
-        if (timeoutId) clearTimeout(timeoutId);
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-
-        dispatch({
-          type: "stderr",
-          text: errorMessage,
-        });
-        dispatch({ type: "exit", code: 1 });
-        resolve();
-      }
-
-      // Handle errors that might occur during process execution
-      childProcess?.on("error", (error: Error) => {
-        if (timeoutId) clearTimeout(timeoutId);
-        dispatch({
-          type: "stderr",
-          text: error.message,
-        });
-        dispatch({ type: "exit", code: 1 });
-        resolve();
-      });
-    });
   };
 }
 
@@ -210,262 +117,323 @@ export function isCommandAllowed(
   return false;
 }
 
-export function initModel(
-  request: ToolRequest<"bash_command">,
-  context: {
-    nvim: Nvim;
-    options: MagentaOptions;
-    rememberedCommands: Set<string>;
-  },
-): [Model, Thunk<Msg>] {
-  const model: Model = {
-    type: "bash_command",
-    request,
-    state: {
-      state: "pending-user-action",
+export class BashCommandTool {
+  state: State;
+  toolName = "bash_command" as const;
+
+  private constructor(
+    public request: Extract<ToolRequest, { toolName: "bash_command" }>,
+    public context: {
+      nvim: Nvim;
+      options: MagentaOptions;
+      rememberedCommands: Set<string>;
     },
-  };
+  ) {
+    const commandAllowlist = this.context.options.commandAllowlist;
+    const isAllowed = isCommandAllowed(
+      request.input.command,
+      commandAllowlist,
+      this.context.rememberedCommands,
+    );
 
-  const commandAllowlist = context.options.commandAllowlist;
-
-  const isAllowed = isCommandAllowed(
-    request.input.command,
-    commandAllowlist,
-    context.rememberedCommands,
-  );
-
-  // If command is allowed, skip approval and execute immediately
-  if (isAllowed) {
-    const approvedModel: Model = {
-      ...model,
-      state: {
+    if (isAllowed) {
+      this.state = {
         state: "processing",
         stdout: [],
         stderr: [],
         startTime: Date.now(),
         approved: true,
         childProcess: null,
-      },
-    };
-    return [approvedModel, executeCommandThunk(approvedModel)];
+      };
+    } else {
+      this.state = {
+        state: "pending-user-action",
+      };
+    }
   }
 
-  // Otherwise, request user approval as before
-  const thunk: Thunk<Msg> = (dispatch) => {
-    dispatch({ type: "request-user-approval" });
-    return Promise.resolve();
-  };
-
-  return [model, thunk];
-}
-
-export function update(
-  msg: Msg,
-  model: Model,
-): [Model, Thunk<Msg> | undefined] {
-  if (model.state.state === "done" || model.state.state === "error") {
-    return [model, undefined];
+  static create(
+    request: Extract<ToolRequest, { toolName: "bash_command" }>,
+    context: {
+      nvim: Nvim;
+      options: MagentaOptions;
+      rememberedCommands: Set<string>;
+    },
+  ): [BashCommandTool, Thunk<Msg>] {
+    const tool = new BashCommandTool(request, context);
+    return [tool, tool.executeCommand()];
   }
 
-  switch (msg.type) {
-    case "request-user-approval": {
-      if (model.state.state !== "pending-user-action") {
-        return [model, undefined];
-      }
-      return [model, undefined];
+  update(msg: Msg): Thunk<Msg> | undefined {
+    if (this.state.state === "done" || this.state.state === "error") {
+      return;
     }
 
-    case "user-approval": {
-      if (model.state.state !== "pending-user-action") {
-        return [model, undefined];
+    switch (msg.type) {
+      case "request-user-approval": {
+        if (this.state.state !== "pending-user-action") {
+          return;
+        }
+        return;
       }
 
-      if (msg.approved) {
-        const nextModel: Model = {
-          ...model,
-          state: {
+      case "user-approval": {
+        if (this.state.state !== "pending-user-action") {
+          return;
+        }
+
+        if (msg.approved) {
+          this.state = {
             state: "processing",
             stdout: [],
             stderr: [],
             startTime: Date.now(),
             approved: true,
             childProcess: null,
-          },
-        };
-        return [nextModel, executeCommandThunk(nextModel)];
-      } else {
-        return [
-          {
-            ...model,
-            state: {
-              state: "done",
-              result: {
-                type: "tool_result",
-                id: model.request.id,
-                result: {
-                  status: "error",
-                  error: `The user did not allow running this command.`,
-                },
-              },
-            },
-          },
-          undefined,
-        ];
-      }
-    }
-
-    case "stdout": {
-      if (model.state.state !== "processing") {
-        return [model, undefined];
-      }
-
-      const lines = msg.text.split("\n");
-      const stdout = [
-        ...model.state.stdout,
-        ...lines.filter((line) => line.trim() !== ""),
-      ];
-
-      return [
-        {
-          ...model,
-          state: {
-            ...model.state,
-            stdout,
-          },
-        },
-        undefined,
-      ];
-    }
-
-    case "stderr": {
-      if (model.state.state !== "processing") {
-        return [model, undefined];
-      }
-
-      const lines = msg.text.split("\n");
-      const stderr = [
-        ...model.state.stderr,
-        ...lines.filter((line) => line.trim() !== ""),
-      ];
-
-      return [
-        {
-          ...model,
-          state: {
-            ...model.state,
-            stderr,
-          },
-        },
-        undefined,
-      ];
-    }
-
-    case "exit": {
-      if (model.state.state !== "processing") {
-        return [model, undefined];
-      }
-
-      const stdout = model.state.stdout.slice(-5000).join("\n");
-      const stderr = model.state.stderr.slice(-5000).join("\n");
-
-      const stderrSection = stderr.trim()
-        ? `\nstderr:\n\`\`\`\n${stderr}\n\`\`\``
-        : "";
-      return [
-        {
-          ...model,
-          state: {
+          };
+          return this.executeCommand();
+        } else {
+          this.state = {
             state: "done",
             result: {
               type: "tool_result",
-              id: model.request.id,
+              id: this.request.id,
               result: {
-                status: "ok",
-                value: `Exit code: ${msg.code === null ? "null" : String(msg.code)}\nstdout:\n\`\`\`\n${stdout}\n\`\`\`${stderrSection}`,
+                status: "error",
+                error: `The user did not allow running this command.`,
               },
             },
-          },
-        },
-        undefined,
-      ];
-    }
-
-    case "error": {
-      return [
-        {
-          ...model,
-          state: {
-            state: "error",
-            error: msg.error,
-          },
-        },
-        undefined,
-      ];
-    }
-
-    case "terminate": {
-      if (model.state.state !== "processing") {
-        return [model, undefined];
+          };
+        }
+        return;
       }
 
-      if (model.state.childProcess) {
-        model.state.childProcess.kill("SIGTERM");
+      case "stdout": {
+        if (this.state.state !== "processing") {
+          return;
+        }
 
-        return [
-          {
-            ...model,
-            state: {
-              ...model.state,
-              stderr: [
-                ...model.state.stderr,
-                "Process terminated by user with SIGTERM",
-              ],
+        const lines = msg.text.split("\n");
+        this.state.stdout = [
+          ...this.state.stdout,
+          ...lines.filter((line) => line.trim() !== ""),
+        ];
+        return;
+      }
+
+      case "stderr": {
+        if (this.state.state !== "processing") {
+          return;
+        }
+
+        const lines = msg.text.split("\n");
+        this.state.stderr = [
+          ...this.state.stderr,
+          ...lines.filter((line) => line.trim() !== ""),
+        ];
+        return;
+      }
+
+      case "exit": {
+        if (this.state.state !== "processing") {
+          return;
+        }
+
+        const stdout = this.state.stdout.slice(-5000).join("\n");
+        const stderr = this.state.stderr.slice(-5000).join("\n");
+
+        const stderrSection = stderr.trim()
+          ? `\nstderr:\n\`\`\`\n${stderr}\n\`\`\``
+          : "";
+
+        this.state = {
+          state: "done",
+          result: {
+            type: "tool_result",
+            id: this.request.id,
+            result: {
+              status: "ok",
+              value: `Exit code: ${msg.code === null ? "null" : String(msg.code)}\nstdout:\n\`\`\`\n${stdout}\n\`\`\`${stderrSection}`,
             },
           },
-          undefined,
-        ];
+        };
+        return;
       }
-      return [model, undefined];
-    }
 
-    default:
-      assertUnreachable(msg);
+      case "error": {
+        this.state = {
+          state: "error",
+          error: msg.error,
+        };
+        return;
+      }
+
+      case "terminate": {
+        if (this.state.state !== "processing") {
+          return;
+        }
+
+        if (this.state.childProcess) {
+          this.state.childProcess.kill("SIGTERM");
+          this.state.stderr = [
+            ...this.state.stderr,
+            "Process terminated by user with SIGTERM",
+          ];
+        }
+        return;
+      }
+
+      default:
+        assertUnreachable(msg);
+    }
   }
-}
 
-export function view({
-  model,
-  dispatch,
-}: {
-  model: Model;
-  dispatch?: Dispatch<Msg>;
-}) {
-  const { state } = model;
+  executeCommand(): Thunk<Msg> {
+    return async (dispatch: Dispatch<Msg>) =>
+      new Promise((resolve) => {
+        const timeout = 300000; // 5 minute timeout
+        const { command } = this.request.input;
 
-  if (state.state === "pending-user-action") {
-    if (!dispatch) {
-      return d`Waiting for user approval to run command: \`${model.request.input.command}\``;
+        let timeoutId: NodeJS.Timeout | null = null;
+        let childProcess: ReturnType<typeof spawn> | null = null;
+
+        try {
+          timeoutId = setTimeout(() => {
+            if (childProcess) {
+              childProcess.kill();
+            }
+            dispatch({
+              type: "error",
+              error: `Command timed out after ${timeout / 1000} seconds`,
+            });
+            resolve();
+          }, timeout);
+
+          childProcess = spawn("bash", ["-c", command], {
+            stdio: "pipe",
+          });
+
+          if (this.state.state === "processing") {
+            this.state.childProcess = childProcess;
+          }
+
+          childProcess.stdout?.on("data", (data: Buffer) => {
+            const text = data.toString();
+            const lines = text.split("\n");
+            for (const line of lines) {
+              if (line.trim()) {
+                dispatch({ type: "stdout", text: line });
+              }
+            }
+          });
+
+          childProcess.stderr?.on("data", (data: Buffer) => {
+            const text = data.toString();
+            const lines = text.split("\n");
+            for (const line of lines) {
+              if (line.trim()) {
+                dispatch({ type: "stderr", text: line });
+              }
+            }
+          });
+
+          childProcess.on("close", (code: number | null) => {
+            if (timeoutId) clearTimeout(timeoutId);
+            dispatch({ type: "exit", code });
+            resolve();
+          });
+        } catch (error) {
+          if (timeoutId) clearTimeout(timeoutId);
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+
+          dispatch({
+            type: "stderr",
+            text: errorMessage,
+          });
+          dispatch({ type: "exit", code: 1 });
+          resolve();
+        }
+
+        // Handle errors that might occur during process execution
+        childProcess?.on("error", (error: Error) => {
+          if (timeoutId) clearTimeout(timeoutId);
+          dispatch({
+            type: "stderr",
+            text: error.message,
+          });
+          dispatch({ type: "exit", code: 1 });
+        });
+      });
+  }
+
+  getToolResult(): ProviderToolResultContent {
+    const { state } = this;
+
+    switch (state.state) {
+      case "done":
+        // Return the stored result
+        return state.result;
+
+      case "error":
+        return {
+          type: "tool_result",
+          id: this.request.id,
+          result: {
+            status: "error",
+            error: `Error: ${state.error}`,
+          },
+        };
+
+      case "pending-user-action":
+        return {
+          type: "tool_result",
+          id: this.request.id,
+          result: {
+            status: "ok",
+            value: `Waiting for user approval to run this command.`,
+          },
+        };
+
+      case "processing":
+        return {
+          type: "tool_result",
+          id: this.request.id,
+          result: {
+            status: "ok",
+            value: "Command still running",
+          },
+        };
+
+      default:
+        assertUnreachable(state);
     }
-    return d`⏳ May I run this command? \`${model.request.input.command}\`
+  }
+
+  view(dispatch: Dispatch<Msg>) {
+    const { state } = this;
+
+    if (state.state === "pending-user-action") {
+      return d`⏳ May I run this command? \`${this.request.input.command}\`
 ${withBindings(d`**[ NO ]**`, {
   "<CR>": () => dispatch({ type: "user-approval", approved: false }),
 })} ${withBindings(d`**[ YES ]**`, {
-      "<CR>": () => dispatch({ type: "user-approval", approved: true }),
-    })} ${withBindings(d`**[ ALWAYS ]**`, {
-      "<CR>": () =>
-        dispatch({ type: "user-approval", approved: true, remember: true }),
-    })}`;
-  }
+        "<CR>": () => dispatch({ type: "user-approval", approved: true }),
+      })} ${withBindings(d`**[ ALWAYS ]**`, {
+        "<CR>": () =>
+          dispatch({ type: "user-approval", approved: true, remember: true }),
+      })}`;
+    }
 
-  if (state.state === "processing") {
-    const runningTime = Math.floor((Date.now() - state.startTime) / 1000);
-    const stderrSection = state.stderr.length
-      ? `\nstderr:\n\`\`\`\n${state.stderr.join("\n")}\n\`\`\``
-      : "";
+    if (state.state === "processing") {
+      const runningTime = Math.floor((Date.now() - state.startTime) / 1000);
+      const stderrSection = state.stderr.length
+        ? `\nstderr:\n\`\`\`\n${state.stderr.join("\n")}\n\`\`\``
+        : "";
 
-    const content = d`Running command (timeout: 300s, running: ${String(runningTime)}s)
+      const content = d`Running command (timeout: 300s, running: ${String(runningTime)}s)
 \`\`\`
-${model.request.input.command}
+${this.request.input.command}
 \`\`\`
 
 stdout:
@@ -473,71 +441,30 @@ stdout:
 ${state.stdout.join("\n")}
 \`\`\`${stderrSection}`;
 
-    if (!dispatch) {
-      return content;
+      return withBindings(content, {
+        t: () => dispatch({ type: "terminate" }),
+      });
     }
 
-    return withBindings(content, {
-      t: () => dispatch({ type: "terminate" }),
-    });
-  }
-
-  if (state.state === "done") {
-    // Display the result content
-    return d`Command:
+    if (state.state === "done") {
+      // Display the result content
+      return d`Command:
 \`\`\`
-${model.request.input.command}
+${this.request.input.command}
 \`\`\`
 
 ${state.result.result.status === "ok" ? state.result.result.value : state.result.result.error}`;
+    }
+
+    if (state.state === "error") {
+      return d`Error running command: ${state.error}`;
+    }
+
+    return d``;
   }
-
-  if (state.state === "error") {
-    return d`Error running command: ${state.error}`;
-  }
-
-  return d``;
-}
-
-export function getToolResult(model: Model): ProviderToolResultContent {
-  const { state } = model;
-
-  switch (state.state) {
-    case "done":
-      // Return the stored result
-      return state.result;
-
-    case "error":
-      return {
-        type: "tool_result",
-        id: model.request.id,
-        result: {
-          status: "error",
-          error: `Error: ${state.error}`,
-        },
-      };
-
-    case "pending-user-action":
-      return {
-        type: "tool_result",
-        id: model.request.id,
-        result: {
-          status: "ok",
-          value: `Waiting for user approval to run this command.`,
-        },
-      };
-
-    case "processing":
-      return {
-        type: "tool_result",
-        id: model.request.id,
-        result: {
-          status: "ok",
-          value: "Command still running",
-        },
-      };
-
-    default:
-      assertUnreachable(state);
+  displayInput(): string {
+    return `bash_command: {
+    command: ${this.request.input.command}
+}`;
   }
 }

--- a/node/tools/diagnostics.spec.ts
+++ b/node/tools/diagnostics.spec.ts
@@ -49,11 +49,11 @@ describe("node/tools/diagnostics.spec.ts", () => {
 
       const result = await pollUntil(
         () => {
-          const state = driver.magenta.chatApp.getState();
-          if (state.status != "running") {
-            throw new Error(`app crashed`);
+          const state = driver.magenta.chat.state;
+          if (state.state != "initialized") {
+            throw new Error(`thread not initialized`);
           }
-          const thread = state.model.thread;
+          const thread = state.thread;
 
           const toolWrapper =
             thread.toolManager.state.toolWrappers[toolRequestId];

--- a/node/tools/diagnostics.spec.ts
+++ b/node/tools/diagnostics.spec.ts
@@ -40,7 +40,7 @@ describe("node/tools/diagnostics.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "diagnostics",
+              toolName: "diagnostics",
               input: {},
             },
           },
@@ -53,20 +53,21 @@ describe("node/tools/diagnostics.spec.ts", () => {
           if (state.status != "running") {
             throw new Error(`app crashed`);
           }
+          const thread = state.model.thread;
 
           const toolWrapper =
-            state.model.thread.state.toolManager.toolWrappers[toolRequestId];
+            thread.toolManager.state.toolWrappers[toolRequestId];
           if (!toolWrapper) {
             throw new Error(
               `could not find toolWrapper with id ${toolRequestId}`,
             );
           }
 
-          if (toolWrapper.model.state.state != "done") {
+          if (toolWrapper.tool.state.state != "done") {
             throw new Error(`Request not done`);
           }
 
-          return toolWrapper.model.state.result;
+          return toolWrapper.tool.state.result;
         },
         { timeout: 5000 },
       );

--- a/node/tools/diff.spec.ts
+++ b/node/tools/diff.spec.ts
@@ -27,7 +27,7 @@ describe("node/tools/diff.spec.ts", () => {
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "poem.txt",
                 insertAfter: "",
@@ -91,7 +91,7 @@ describe("node/tools/diff.spec.ts", () => {
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "node/test/fixtures/toolManager.ts",
                 insertAfter: "",
@@ -144,7 +144,7 @@ describe("node/tools/diff.spec.ts", () => {
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "replace",
+              toolName: "replace",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 find: `\
@@ -218,7 +218,7 @@ Paints its colors in the light.`,
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "poem.txt",
                 insertAfter: "",
@@ -255,7 +255,7 @@ Paints its colors in the light.`,
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "poem.txt",
                 insertAfter: "",
@@ -305,7 +305,7 @@ Paints its colors in the light.`,
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "replace",
+              toolName: "replace",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 find: "Silver shadows dance with ease.",
@@ -362,7 +362,7 @@ Paints its colors in the light.`,
             status: "ok",
             value: {
               id: "id1" as ToolRequestId,
-              name: "replace",
+              toolName: "replace",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 find: `bogus line...`,
@@ -374,7 +374,7 @@ Paints its colors in the light.`,
             status: "ok",
             value: {
               id: "id2" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 insertAfter: `Paint their stories in the night.`,

--- a/node/tools/diff.ts
+++ b/node/tools/diff.ts
@@ -1,18 +1,16 @@
 import { WIDTH } from "../sidebar.ts";
 import { assertUnreachable } from "../utils/assertUnreachable.ts";
-import type { Dispatch } from "../tea/tea.ts";
 import { diffthis, getAllWindows } from "../nvim/nvim.ts";
 import { NvimBuffer, type Line } from "../nvim/buffer.ts";
 import { type WindowId } from "../nvim/window.ts";
 import type { Nvim } from "nvim-node";
-import type { ToolRequest, ToolRequestId } from "./toolManager.ts";
-
-type Msg = {
-  type: "diff-error";
-  filePath: string;
-  requestId: ToolRequestId;
-  message: string;
-};
+import type {
+  ToolRequest,
+  ToolRequestId,
+  Msg as ToolManagerMsg,
+  ToolManager,
+  ToolMsg,
+} from "./toolManager.ts";
 
 /** Helper to bring up an editing interface for the given file path.
  */
@@ -21,6 +19,7 @@ export async function displayDiffs({
   diffId,
   edits,
   dispatch,
+  toolManager,
   context,
 }: {
   filePath: string;
@@ -29,14 +28,36 @@ export async function displayDiffs({
    * file.
    */
   diffId: string;
-  edits: (ToolRequest<"replace"> | ToolRequest<"insert">)[];
-  dispatch: Dispatch<Msg>;
+  edits: (
+    | Extract<ToolRequest, { toolName: "replace" }>
+    | Extract<ToolRequest, { toolName: "insert" }>
+  )[];
+  dispatch: (msg: ToolManagerMsg) => void;
+  toolManager: ToolManager;
   context: { nvim: Nvim };
 }) {
   const { nvim } = context;
   nvim.logger?.debug(
     `Attempting to displayDiff for edits ${JSON.stringify(edits, null, 2)}`,
   );
+
+  function dispatchError(requestId: ToolRequestId, error: string) {
+    const toolWrapper = toolManager.state.toolWrappers[requestId];
+    dispatch({
+      type: "tool-msg",
+      msg: {
+        id: requestId,
+        toolName: toolWrapper.tool.toolName,
+        msg: {
+          type: "finish",
+          result: {
+            status: "error",
+            error,
+          },
+        },
+      } as ToolMsg,
+    });
+  }
 
   // first, check to see if any windows *other than* the magenta plugin windows are open, and close them.
   const windows = await getAllWindows(context.nvim);
@@ -73,7 +94,7 @@ export async function displayDiffs({
   let content: string = lines.join("\n");
 
   for (const edit of edits) {
-    switch (edit.name) {
+    switch (edit.toolName) {
       case "insert": {
         if (edit.input.insertAfter === "") {
           content = edit.input.content + content;
@@ -82,12 +103,10 @@ export async function displayDiffs({
 
         const insertIndex = content.indexOf(edit.input.insertAfter);
         if (insertIndex === -1) {
-          dispatch({
-            type: "diff-error",
-            filePath,
-            requestId: edit.id,
-            message: `Unable to find insert location "${edit.input.insertAfter}" in file \`${filePath}\``,
-          });
+          dispatchError(
+            edit.id,
+            `Unable to find insert location "${edit.input.insertAfter}" in file \`${filePath}\``,
+          );
           continue;
         }
 
@@ -104,12 +123,10 @@ export async function displayDiffs({
         const replaceEnd = replaceStart + edit.input.find.length;
 
         if (replaceStart == -1) {
-          dispatch({
-            type: "diff-error",
-            filePath,
-            requestId: edit.id,
-            message: `Unable to find text "${edit.input.find}" in file \`${filePath}\``,
-          });
+          dispatchError(
+            edit.id,
+            `Unable to find text "${edit.input.find}" in file \`${filePath}\``,
+          );
           continue;
         }
 

--- a/node/tools/findReferences.spec.ts
+++ b/node/tools/findReferences.spec.ts
@@ -33,12 +33,12 @@ describe("node/tools/findReferences.spec.ts", () => {
 
       const result = await pollUntil(
         () => {
-          const state = driver.magenta.chatApp.getState();
-          if (state.status != "running") {
-            throw new Error(`app crashed`);
+          const state = driver.magenta.chat.state;
+          if (state.state != "initialized") {
+            throw new Error(`thread not initialized`);
           }
 
-          const thread = state.model.thread;
+          const thread = state.thread;
           if (!thread || !thread.state || typeof thread.state !== "object") {
             throw new Error("Thread state is not valid");
           }

--- a/node/tools/findReferences.spec.ts
+++ b/node/tools/findReferences.spec.ts
@@ -21,7 +21,7 @@ describe("node/tools/findReferences.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "find_references",
+              toolName: "find_references",
               input: {
                 filePath: "node/test/fixtures/test.ts",
                 symbol: "val.a.b.c",
@@ -38,19 +38,24 @@ describe("node/tools/findReferences.spec.ts", () => {
             throw new Error(`app crashed`);
           }
 
+          const thread = state.model.thread;
+          if (!thread || !thread.state || typeof thread.state !== "object") {
+            throw new Error("Thread state is not valid");
+          }
+
           const toolWrapper =
-            state.model.thread.state.toolManager.toolWrappers[toolRequestId];
+            thread.toolManager.state.toolWrappers[toolRequestId];
           if (!toolWrapper) {
             throw new Error(
               `could not find toolWrapper with id ${toolRequestId}`,
             );
           }
 
-          if (toolWrapper.model.state.state != "done") {
+          if (toolWrapper.tool.state.state != "done") {
             throw new Error(`Request not done`);
           }
 
-          return toolWrapper.model.state.result;
+          return toolWrapper.tool.state.result;
         },
         { timeout: 3000 },
       );

--- a/node/tools/getFile.ts
+++ b/node/tools/getFile.ts
@@ -2,8 +2,7 @@ import { getBufferIfOpen } from "../utils/buffers.ts";
 import fs from "fs";
 import path from "path";
 import { assertUnreachable } from "../utils/assertUnreachable.ts";
-import { type Dispatch, type Thunk, type Update } from "../tea/tea.ts";
-import { d, withBindings, type View } from "../tea/view.ts";
+import { d, withBindings } from "../tea/view.ts";
 import { type ToolRequest } from "./toolManager.ts";
 import { type Result } from "../utils/result.ts";
 import { getcwd } from "../nvim/nvim.ts";
@@ -13,23 +12,20 @@ import type {
   ProviderToolResultContent,
   ProviderToolSpec,
 } from "../providers/provider.ts";
+import type { Dispatch, Thunk } from "../tea/tea.ts";
 
-export type Model = {
-  type: "get_file";
-  request: ToolRequest<"get_file">;
-  state:
-    | {
-        state: "processing";
-        approved: boolean;
-      }
-    | {
-        state: "pending-user-action";
-      }
-    | {
-        state: "done";
-        result: ProviderToolResultContent;
-      };
-};
+export type State =
+  | {
+      state: "processing";
+      approved: boolean;
+    }
+  | {
+      state: "pending-user-action";
+    }
+  | {
+      state: "done";
+      result: ProviderToolResultContent;
+    };
 
 export type Msg =
   | {
@@ -44,217 +40,210 @@ export type Msg =
       approved: boolean;
     };
 
-export const update: Update<Msg, Model, { nvim: Nvim }> = (
-  msg,
-  model,
-  context: { nvim: Nvim },
-) => {
-  switch (msg.type) {
-    case "finish":
-      return [
-        {
-          ...model,
-          state: {
-            state: "done",
-            result: {
-              type: "tool_result",
-              id: model.request.id,
-              result: msg.result,
-            },
-          },
-        },
-      ];
-    case "request-user-approval":
-      return [
-        {
-          ...model,
-          state: {
-            state: "pending-user-action",
-          },
-        },
-      ];
-    case "user-approval": {
-      if (model.state.state == "pending-user-action") {
-        if (msg.approved) {
-          const nextModel: Model = {
-            ...model,
-            state: { state: "processing", approved: true },
-          };
-          return [nextModel, readFileThunk(nextModel, context)];
-        } else {
-          return [
-            {
-              ...model,
-              state: {
-                state: "done",
-                result: {
-                  type: "tool_result",
-                  id: model.request.id,
-                  result: {
-                    status: "error",
-                    error: `The user did not allow the reading of this file.`,
-                  },
-                },
-              },
-            },
-          ];
-        }
-      } else {
-        throw new Error(
-          `Unexpected message ${msg.type} when model state is ${model.state.state}`,
-        );
-      }
-    }
-    default:
-      assertUnreachable(msg);
-  }
-};
+export class GetFileTool {
+  state: State;
+  toolName = "get_file" as const;
 
-function readFileThunk(model: Model, context: { nvim: Nvim }) {
-  const thunk: Thunk<Msg> = async (dispatch: Dispatch<Msg>) => {
-    const filePath = model.request.input.filePath;
-    const cwd = await getcwd(context.nvim);
-    const absolutePath = path.resolve(cwd, filePath);
-    const relativePath = path.relative(cwd, absolutePath);
-
-    if (!(model.state.state === "processing" && model.state.approved)) {
-      if (!absolutePath.startsWith(cwd)) {
-        dispatch({ type: "request-user-approval" });
-        return;
-      }
-
-      if (relativePath.split(path.sep).some((part) => part.startsWith("."))) {
-        dispatch({ type: "request-user-approval" });
-        return;
-      }
-
-      const ig = await readGitignore(cwd);
-      if (ig.ignores(relativePath)) {
-        dispatch({ type: "request-user-approval" });
-        return;
-      }
-    }
-
-    const bufferContents = await getBufferIfOpen({
-      relativePath: filePath,
-      context,
-    });
-
-    if (bufferContents.status === "ok") {
-      dispatch({
-        type: "finish",
-        result: {
-          status: "ok",
-          value: (
-            await bufferContents.buffer.getLines({ start: 0, end: -1 })
-          ).join("\n"),
-        },
-      });
-      return;
-    }
-
-    if (bufferContents.status === "error") {
-      dispatch({
-        type: "finish",
-        result: {
-          status: "error",
-          error: bufferContents.error,
-        },
-      });
-      return;
-    }
-
-    try {
-      const fileContent = await fs.promises.readFile(absolutePath, "utf-8");
-      dispatch({
-        type: "finish",
-        result: {
-          status: "ok",
-          value: fileContent,
-        },
-      });
-      return;
-    } catch (error) {
-      dispatch({
-        type: "finish",
-        result: {
-          status: "error",
-          error: `Failed to read file: ${(error as Error).message}`,
-        },
-      });
-    }
-  };
-
-  return thunk;
-}
-
-export function initModel(
-  request: ToolRequest<"get_file">,
-  context: { nvim: Nvim },
-): [Model, Thunk<Msg>] {
-  const model: Model = {
-    type: "get_file",
-    request,
-    state: {
+  private constructor(
+    public request: Extract<ToolRequest, { toolName: "get_file" }>,
+    public context: { nvim: Nvim },
+  ) {
+    this.state = {
       state: "processing",
       approved: false,
-    },
-  };
-
-  return [model, readFileThunk(model, context)];
-}
-
-export const view: View<{ model: Model; dispatch: Dispatch<Msg> }> = ({
-  model,
-  dispatch,
-}) => {
-  switch (model.state.state) {
-    case "processing":
-      return d`⚙️ Reading file ${model.request.input.filePath}`;
-    case "pending-user-action":
-      return d`⏳ May I read file \`${model.request.input.filePath}\`? ${withBindings(
-        d`**[ NO ]**`,
-        {
-          "<CR>": () => dispatch({ type: "user-approval", approved: false }),
-        },
-      )} ${withBindings(d`**[ OK ]**`, {
-        "<CR>": () => dispatch({ type: "user-approval", approved: true }),
-      })}`;
-    case "done":
-      if (model.state.result.result.status == "error") {
-        return d`❌ Error reading file \`${model.request.input.filePath}\`: ${model.state.result.result.error}`;
-      } else {
-        return d`✅ Finished reading file \`${model.request.input.filePath}\``;
-      }
-    default:
-      assertUnreachable(model.state);
+    };
   }
-};
 
-export function getToolResult(model: Model): ProviderToolResultContent {
-  switch (model.state.state) {
-    case "processing":
-      return {
-        type: "tool_result",
-        id: model.request.id,
-        result: {
-          status: "ok",
-          value: `This tool use is being processed. Please proceed with your answer or address other parts of the question.`,
-        },
-      };
-    case "pending-user-action":
-      return {
-        type: "tool_result",
-        id: model.request.id,
-        result: {
-          status: "ok",
-          value: `Waiting for user approval to finish processing this tool use.`,
-        },
-      };
-    case "done":
-      return model.state.result;
-    default:
-      assertUnreachable(model.state);
+  static create(
+    request: Extract<ToolRequest, { toolName: "get_file" }>,
+    context: { nvim: Nvim },
+  ): [GetFileTool, Thunk<Msg>] {
+    const tool = new GetFileTool(request, context);
+    return [tool, tool.readFileThunk()];
+  }
+
+  update(msg: Msg): Thunk<Msg> | undefined {
+    switch (msg.type) {
+      case "finish":
+        this.state = {
+          state: "done",
+          result: {
+            type: "tool_result",
+            id: this.request.id,
+            result: msg.result,
+          },
+        };
+        return;
+      case "request-user-approval":
+        this.state = {
+          state: "pending-user-action",
+        };
+        return;
+      case "user-approval": {
+        if (this.state.state === "pending-user-action") {
+          if (msg.approved) {
+            this.state = {
+              state: "processing",
+              approved: true,
+            };
+
+            return this.readFileThunk();
+          } else {
+            this.state = {
+              state: "done",
+              result: {
+                type: "tool_result",
+                id: this.request.id,
+                result: {
+                  status: "error",
+                  error: `The user did not allow the reading of this file.`,
+                },
+              },
+            };
+            return;
+          }
+        } else {
+          throw new Error(
+            `Unexpected message ${msg.type} when model state is ${this.state.state}`,
+          );
+        }
+      }
+      default:
+        assertUnreachable(msg);
+    }
+  }
+
+  readFileThunk(): Thunk<Msg> {
+    return async (dispatch: Dispatch<Msg>) => {
+      const filePath = this.request.input.filePath;
+      const cwd = await getcwd(this.context.nvim);
+      const absolutePath = path.resolve(cwd, filePath);
+      const relativePath = path.relative(cwd, absolutePath);
+
+      if (!(this.state.state === "processing" && this.state.approved)) {
+        if (!absolutePath.startsWith(cwd)) {
+          dispatch({ type: "request-user-approval" });
+          return;
+        }
+
+        if (relativePath.split(path.sep).some((part) => part.startsWith("."))) {
+          dispatch({ type: "request-user-approval" });
+          return;
+        }
+
+        const ig = await readGitignore(cwd);
+        if (ig.ignores(relativePath)) {
+          dispatch({ type: "request-user-approval" });
+          return;
+        }
+      }
+
+      const bufferContents = await getBufferIfOpen({
+        relativePath: filePath,
+        context: this.context,
+      });
+
+      if (bufferContents.status === "ok") {
+        dispatch({
+          type: "finish",
+          result: {
+            status: "ok",
+            value: (
+              await bufferContents.buffer.getLines({ start: 0, end: -1 })
+            ).join("\n"),
+          },
+        });
+        return;
+      }
+
+      if (bufferContents.status === "error") {
+        dispatch({
+          type: "finish",
+          result: {
+            status: "error",
+            error: bufferContents.error,
+          },
+        });
+        return;
+      }
+
+      try {
+        const fileContent = await fs.promises.readFile(absolutePath, "utf-8");
+        dispatch({
+          type: "finish",
+          result: {
+            status: "ok",
+            value: fileContent,
+          },
+        });
+        return;
+      } catch (error) {
+        dispatch({
+          type: "finish",
+          result: {
+            status: "error",
+            error: `Failed to read file: ${(error as Error).message}`,
+          },
+        });
+      }
+    };
+  }
+
+  getToolResult(): ProviderToolResultContent {
+    switch (this.state.state) {
+      case "processing":
+        return {
+          type: "tool_result",
+          id: this.request.id,
+          result: {
+            status: "ok",
+            value: `This tool use is being processed. Please proceed with your answer or address other parts of the question.`,
+          },
+        };
+      case "pending-user-action":
+        return {
+          type: "tool_result",
+          id: this.request.id,
+          result: {
+            status: "ok",
+            value: `Waiting for user approval to finish processing this tool use.`,
+          },
+        };
+      case "done":
+        return this.state.result;
+      default:
+        assertUnreachable(this.state);
+    }
+  }
+
+  view(dispatch: Dispatch<Msg>) {
+    switch (this.state.state) {
+      case "processing":
+        return d`⚙️ Reading file ${this.request.input.filePath}`;
+      case "pending-user-action":
+        return d`⏳ May I read file \`${this.request.input.filePath}\`? ${withBindings(
+          d`**[ NO ]**`,
+          {
+            "<CR>": () => dispatch({ type: "user-approval", approved: false }),
+          },
+        )} ${withBindings(d`**[ OK ]**`, {
+          "<CR>": () => dispatch({ type: "user-approval", approved: true }),
+        })}`;
+      case "done":
+        if (this.state.result.result.status == "error") {
+          return d`❌ Error reading file \`${this.request.input.filePath}\`: ${this.state.result.result.error}`;
+        } else {
+          return d`✅ Finished reading file \`${this.request.input.filePath}\``;
+        }
+      default:
+        assertUnreachable(this.state);
+    }
+  }
+
+  displayInput() {
+    return `get_file: {
+    filePath: ${this.request.input.filePath}
+}`;
   }
 }
 
@@ -278,12 +267,6 @@ export const spec: ProviderToolSpec = {
 export type Input = {
   filePath: string;
 };
-
-export function displayInput(input: Input) {
-  return `get_file: {
-    filePath: ${input.filePath}
-}`;
-}
 
 export function validateInput(input: {
   [key: string]: unknown;

--- a/node/tools/hover.spec.ts
+++ b/node/tools/hover.spec.ts
@@ -22,7 +22,7 @@ describe("node/tools/hover.spec.ts", () => {
             status: "ok",
             value: {
               id: toolRequestId,
-              name: "hover",
+              toolName: "hover",
               input: {
                 filePath: "node/test/fixtures/test.ts",
                 symbol: "val.a.b.c",
@@ -39,19 +39,24 @@ describe("node/tools/hover.spec.ts", () => {
             throw new Error(`app crashed`);
           }
 
+          const thread = state.model.thread;
+          if (!thread || !thread.state || typeof thread.state !== "object") {
+            throw new Error("Thread state is not valid");
+          }
+
           const toolWrapper =
-            state.model.thread.state.toolManager.toolWrappers[toolRequestId];
+            thread.toolManager.state.toolWrappers[toolRequestId];
           if (!toolWrapper) {
             throw new Error(
               `could not find toolWrapper with id ${toolRequestId}`,
             );
           }
 
-          if (toolWrapper.model.state.state != "done") {
+          if (toolWrapper.tool.state.state != "done") {
             throw new Error(`Request not done`);
           }
 
-          return toolWrapper.model.state.result;
+          return toolWrapper.tool.state.result;
         },
         { timeout: 5000 },
       );

--- a/node/tools/hover.spec.ts
+++ b/node/tools/hover.spec.ts
@@ -34,12 +34,12 @@ describe("node/tools/hover.spec.ts", () => {
 
       const result = await pollUntil(
         () => {
-          const state = driver.magenta.chatApp.getState();
-          if (state.status != "running") {
-            throw new Error(`app crashed`);
+          const state = driver.magenta.chat.state;
+          if (state.state != "initialized") {
+            throw new Error(`thread not ready`);
           }
 
-          const thread = state.model.thread;
+          const thread = state.thread;
           if (!thread || !thread.state || typeof thread.state !== "object") {
             throw new Error("Thread state is not valid");
           }

--- a/node/tools/insert.spec.ts
+++ b/node/tools/insert.spec.ts
@@ -13,9 +13,9 @@ describe("node/tools/insert.spec.ts", () => {
     await withNvimClient(async (nvim) => {
       const buffer = await NvimBuffer.create(false, true, nvim);
       await buffer.setOption("modifiable", false);
-      const [model] = Insert.initModel({
+      const tool = new Insert.InsertTool({
         id: "request_id" as ToolRequestId,
-        name: "insert",
+        toolName: "insert",
         input: {
           filePath: "./test.txt",
           insertAfter: "existing line",
@@ -23,11 +23,14 @@ describe("node/tools/insert.spec.ts", () => {
         },
       });
 
-      const app = createApp<Insert.Model, Insert.Msg>({
+      const app = createApp<{ tool: Insert.InsertTool }, Insert.Msg>({
         nvim,
-        initialModel: model,
-        update: Insert.update,
-        View: Insert.view,
+        initialModel: { tool },
+        update: (msg, model) => {
+          model.tool.update(msg);
+          return [model];
+        },
+        View: ({ model }) => model.tool.view(),
       });
 
       const mountedApp = await app.mount({
@@ -76,7 +79,7 @@ describe("node/tools/insert.spec.ts", () => {
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "test_note.txt",
                 insertAfter: "",
@@ -137,7 +140,7 @@ describe("node/tools/insert.spec.ts", () => {
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 insertAfter: "Paint their stories in the night.",
@@ -193,7 +196,7 @@ describe("node/tools/insert.spec.ts", () => {
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 insertAfter: "",
@@ -244,7 +247,7 @@ describe("node/tools/insert.spec.ts", () => {
             status: "ok",
             value: {
               id: "id" as ToolRequestId,
-              name: "insert",
+              toolName: "insert",
               input: {
                 filePath: "node/test/fixtures/poem.txt",
                 insertAfter: "Text that doesn't exist in the file",

--- a/node/tools/insert.ts
+++ b/node/tools/insert.ts
@@ -1,7 +1,7 @@
 import { assertUnreachable } from "../utils/assertUnreachable.ts";
-import { type Dispatch, type Update } from "../tea/tea.ts";
 import { d, type VDOMNode } from "../tea/view.ts";
 import { type Result } from "../utils/result.ts";
+import type { Thunk } from "../tea/tea.ts";
 import type { ToolRequest } from "./toolManager.ts";
 import type {
   ProviderToolResultContent,
@@ -9,13 +9,9 @@ import type {
 } from "../providers/provider.ts";
 import { REVIEW_PROMPT } from "./diff.ts";
 
-export type Model = {
-  type: "insert";
-  request: ToolRequest<"insert">;
-  state: {
-    state: "done";
-    result: ProviderToolResultContent;
-  };
+export type State = {
+  state: "done";
+  result: ProviderToolResultContent;
 };
 
 export type Msg = {
@@ -23,32 +19,12 @@ export type Msg = {
   result: Result<string>;
 };
 
-export const update: Update<Msg, Model> = (msg, model) => {
-  switch (msg.type) {
-    case "finish":
-      return [
-        {
-          ...model,
-          state: {
-            state: "done",
-            result: {
-              type: "tool_result",
-              id: model.request.id,
-              result: msg.result,
-            },
-          },
-        },
-      ];
-    default:
-      assertUnreachable(msg.type);
-  }
-};
+export class InsertTool {
+  state: State;
+  toolName = "insert" as const;
 
-export function initModel(request: ToolRequest<"insert">): [Model] {
-  const model: Model = {
-    type: "insert",
-    request,
-    state: {
+  constructor(public request: Extract<ToolRequest, { toolName: "insert" }>) {
+    this.state = {
       state: "done",
       result: {
         type: "tool_result",
@@ -58,46 +34,61 @@ export function initModel(request: ToolRequest<"insert">): [Model] {
           value: REVIEW_PROMPT,
         },
       },
-    },
-  };
-
-  return [model];
-}
-
-export function view({
-  model,
-  dispatch,
-}: {
-  model: Model;
-  dispatch: Dispatch<Msg>;
-}): VDOMNode {
-  return d`Insert [[ +${(
-    (model.request.input.content.match(/\n/g) || []).length + 1
-  ).toString()} ]] in \`${model.request.input.filePath}\` ${toolStatusView({ model, dispatch })}`;
-}
-
-function toolStatusView({
-  model,
-}: {
-  model: Model;
-  dispatch: Dispatch<Msg>;
-}): VDOMNode {
-  switch (model.state.state) {
-    case "done":
-      if (model.state.result.result.status == "error") {
-        return d`⚠️ Error: ${JSON.stringify(model.state.result.result.error, null, 2)}`;
-      } else {
-        return d`Awaiting user review.`;
-      }
+    };
   }
-}
 
-export function getToolResult(model: Model): ProviderToolResultContent {
-  switch (model.state.state) {
-    case "done":
-      return model.state.result;
-    default:
-      assertUnreachable(model.state.state);
+  update(msg: Msg): Thunk<Msg> | undefined {
+    switch (msg.type) {
+      case "finish":
+        this.state = {
+          state: "done",
+          result: {
+            type: "tool_result",
+            id: this.request.id,
+            result: msg.result,
+          },
+        };
+        return;
+      default:
+        assertUnreachable(msg.type);
+    }
+  }
+
+  view(): VDOMNode {
+    return d`Insert [[ +${(
+      (this.request.input.content.match(/\n/g) || []).length + 1
+    ).toString()} ]] in \`${this.request.input.filePath}\` ${this.toolStatusView()}`;
+  }
+
+  toolStatusView(): VDOMNode {
+    switch (this.state.state) {
+      case "done":
+        if (this.state.result.result.status == "error") {
+          return d`⚠️ Error: ${JSON.stringify(this.state.result.result.error, null, 2)}`;
+        } else {
+          return d`Awaiting user review.`;
+        }
+    }
+  }
+
+  getToolResult(): ProviderToolResultContent {
+    switch (this.state.state) {
+      case "done":
+        return this.state.result;
+      default:
+        assertUnreachable(this.state.state);
+    }
+  }
+
+  displayInput() {
+    return `insert: {
+    filePath: ${this.request.input.filePath}
+    insertAfter: "${this.request.input.insertAfter}"
+    content:
+\`\`\`
+${this.request.input.content}
+\`\`\`
+}`;
   }
 }
 
@@ -138,17 +129,6 @@ export type Input = {
   insertAfter: string;
   content: string;
 };
-
-export function displayInput(input: Input) {
-  return `insert: {
-    filePath: ${input.filePath}
-    insertAfter: "${input.insertAfter}"
-    content:
-\`\`\`
-${input.content}
-\`\`\`
-}`;
-}
 
 export function validateInput(input: {
   [key: string]: unknown;


### PR DESCRIPTION
I've been feeling frustrated with the dispatch wrapping, message wrapping, thunk wrapping. I think TEA is maybe a bit verbose / unnecessarily rigid for this.

Changing things to be controllers, with state that's mutated.

Dispatches still go through the root and flow down via explicit update calls.

I'm not requiring actions to be strictly nested any more. Context has access to a root dispatch method that any controller can use. Generally the expectation is that if you create a controller, you are responsible for forwarding msgs to it.

We no longer need to return thunks - we can now just invoke them as promises. Make sure you handle the promise and update the controller state accordingly.

I also put an intermediate "chat" between magenta and thread, to simplify initialization async code, and in anticipation of having multiple threads.

