### PR TITLE
Add system information after system prompts

### DIFF
--- a/node/chat/thread.ts
+++ b/node/chat/thread.ts
@@ -42,7 +42,7 @@ import {
 
 import type { Chat } from "./chat.ts";
 import type { ThreadId, ThreadType } from "./types.ts";
-import { getSystemPrompt } from "../providers/system-prompt.ts";
+import type { SystemPrompt } from "../providers/system-prompt.ts";
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -144,6 +144,7 @@ export class Thread {
     conversation: ConversationState;
     messages: Message[];
     threadType: ThreadType;
+    systemPrompt: SystemPrompt;
   };
 
   private myDispatch: Dispatch<Msg>;
@@ -155,6 +156,7 @@ export class Thread {
   constructor(
     public id: ThreadId,
     threadType: ThreadType,
+    systemPrompt: SystemPrompt,
     public context: {
       dispatch: Dispatch<RootMsg>;
       chat: Chat;
@@ -201,6 +203,7 @@ export class Thread {
       },
       messages: [],
       threadType: threadType,
+      systemPrompt: systemPrompt,
     };
   }
 
@@ -367,6 +370,7 @@ export class Thread {
           },
           messages: [],
           threadType: this.state.threadType,
+          systemPrompt: this.state.systemPrompt,
         };
         this.contextManager.reset();
 
@@ -682,7 +686,7 @@ export class Thread {
         });
       },
       tools: this.toolManager.getToolSpecs(this.state.threadType),
-      systemPrompt: getSystemPrompt(this.state.threadType),
+      systemPrompt: this.state.systemPrompt,
     });
 
     this.myDispatch({
@@ -733,7 +737,7 @@ ${text}`;
         },
       ],
       spec: compactThreadSpec,
-      systemPrompt: getSystemPrompt(this.state.threadType),
+      systemPrompt: this.state.systemPrompt,
     });
 
     this.myDispatch({
@@ -879,7 +883,7 @@ Come up with a succinct thread title for this prompt. It should be less than 80 
         },
       ],
       spec: threadTitleToolSpec,
-      systemPrompt: getSystemPrompt(this.state.threadType),
+      systemPrompt: this.state.systemPrompt,
       disableCaching: true,
     });
     const result = await request.promise;

--- a/node/providers/system-prompt.spec.ts
+++ b/node/providers/system-prompt.spec.ts
@@ -1,0 +1,33 @@
+import { it, expect } from "vitest";
+import { createSystemPrompt } from "./system-prompt.ts";
+import { withDriver } from "../test/preamble.ts";
+
+it("includes system information in the prompt", async () => {
+  await withDriver({}, async (driver) => {
+    const systemPrompt = await createSystemPrompt(
+      "root",
+      driver.magenta.nvim,
+      driver.magenta.cwd,
+    );
+
+    // Check that system information is included
+    expect(systemPrompt).toContain("# System Information");
+    expect(systemPrompt).toContain("- Current time:");
+    expect(systemPrompt).toContain("- Operating system:");
+    expect(systemPrompt).toContain("- Neovim version:");
+    expect(systemPrompt).toContain("- Current working directory:");
+
+    // Verify the platform is included
+    expect(systemPrompt).toMatch(/- Operating system: (darwin|linux|win32)/);
+
+    // Verify the timestamp format
+    expect(systemPrompt).toMatch(
+      /- Current time: \w+ \w+ \d+ \d+ \d+:\d+:\d+ GMT/,
+    );
+
+    // Verify cwd is included
+    expect(systemPrompt).toContain(
+      `- Current working directory: ${driver.magenta.cwd}`,
+    );
+  });
+});


### PR DESCRIPTION
- Include current time, OS, neovim version, and cwd in system prompts
- Create branded SystemPrompt type for type safety
- Generate system prompt once at thread creation rather than per request
- Add comprehensive test coverage for system info inclusion
- Support local timezone in timestamp using Date.toString()

The system information is appended to all thread types and provides context about the current environment to the AI assistant.