### PR TITLE
Don't run completion setup if nvim-cmp is missing

### DIFF
--- a/lua/magenta/init.lua
+++ b/lua/magenta/init.lua
@@ -74,7 +74,10 @@ M.bridge = function(channelId)
   M.channel_id = channelId
 
   -- Initialize completion support
-  require('magenta.completion.source').setup()
+  local completion_source = require('magenta.completion.source')
+  if completion_source.setup then
+    completion_source.setup()
+  end
 
   vim.api.nvim_create_user_command(
     "Magenta",


### PR DESCRIPTION
When nvim-cmp is missing, `magenta.completion.source` returns a module that does not have a `setup` function. The plugin currently errors and does not finish initializing in this case.
