### PR TITLE
add sidebar positions: below, above, tab

### DIFF
--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -36,22 +36,22 @@ local defaults = {
   sidebarPosition = "left",
   sidebarPositionOpts = {
     above = {
-      displayHeightPercentage = 0.2,
-      inputHeightPercentage = 0.2,
+      displayHeightPercentage = 0.3,
+      inputHeightPercentage = 0.1,
     },
     below = {
-      displayHeightPercentage = 0.2,
-      inputHeightPercentage = 0.2,
+      displayHeightPercentage = 0.3,
+      inputHeightPercentage = 0.1,
     },
     tab = {
       displayHeightPercentage = 0.8,
     },
     left = {
-      widthPercentage = 0.2,
+      widthPercentage = 0.3,
       displayHeightPercentage = 0.8,
     },
     right = {
-      widthPercentage = 0.2,
+      widthPercentage = 0.3,
       displayHeightPercentage = 0.8,
     }
   },

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -34,6 +34,27 @@ local defaults = {
   },
   picker = "fzf-lua",
   sidebarPosition = "left",
+  sidebarPositionOpts = {
+    above = {
+      displayHeightPercentage = 0.2,
+      inputHeightPercentage = 0.2,
+    },
+    below = {
+      displayHeightPercentage = 0.2,
+      inputHeightPercentage = 0.2,
+    },
+    tab = {
+      displayHeightPercentage = 0.8,
+    },
+    left = {
+      widthPercentage = 0.2,
+      displayHeightPercentage = 0.8,
+    },
+    right = {
+      widthPercentage = 0.2,
+      displayHeightPercentage = 0.8,
+    }
+  },
   defaultKeymaps = true,
   sidebarKeymaps = {
     normal = {

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -47,11 +47,11 @@ local defaults = {
       displayHeightPercentage = 0.8,
     },
     left = {
-      widthPercentage = 0.3,
+      widthPercentage = 0.4,
       displayHeightPercentage = 0.8,
     },
     right = {
-      widthPercentage = 0.3,
+      widthPercentage = 0.4,
       displayHeightPercentage = 0.8,
     }
   },

--- a/node/chat/chat.ts
+++ b/node/chat/chat.ts
@@ -108,6 +108,7 @@ export class Chat {
   constructor(
     private context: {
       dispatch: Dispatch<RootMsg>;
+      getDisplayWidth: () => number;
       bufferTracker: BufferTracker;
       options: MagentaOptions;
       cwd: NvimCwd;

--- a/node/chat/message.ts
+++ b/node/chat/message.ts
@@ -139,6 +139,7 @@ export class Message {
       fileSnapshots: FileSnapshots;
       options: MagentaOptions;
       contextManager: ContextManager;
+      getDisplayWidth: () => number;
     },
   ) {
     this.state = {
@@ -242,6 +243,7 @@ export class Message {
           messageId: this.state.id,
           nvim: this.context.nvim,
           fileSnapshots: this.context.fileSnapshots,
+          getDisplayWidth: this.context.getDisplayWidth,
         }).catch((e: Error) => this.context.nvim.logger.error(e.message));
         return;
       }

--- a/node/chat/thread.ts
+++ b/node/chat/thread.ts
@@ -174,6 +174,7 @@ export class Thread {
       lsp: Lsp;
       contextManager: ContextManager;
       options: MagentaOptions;
+      getDisplayWidth: () => number;
     },
   ) {
     this.myDispatch = (msg) =>
@@ -742,6 +743,7 @@ export class Thread {
           fileSnapshots: this.fileSnapshots,
           options: this.context.options,
           contextManager: this.contextManager,
+          getDisplayWidth: this.context.getDisplayWidth,
         },
       );
 

--- a/node/magenta.ts
+++ b/node/magenta.ts
@@ -260,7 +260,10 @@ export class Magenta {
       }
 
       case "toggle": {
-        const buffers = await this.sidebar.toggle(this.options.sidebarPosition, this.options.sidebarPositionOpts);
+        const buffers = await this.sidebar.toggle(
+          this.options.sidebarPosition,
+          this.options.sidebarPositionOpts,
+        );
         if (buffers && !this.mountedChatApp) {
           this.mountedChatApp = await this.chatApp.mount({
             nvim: this.nvim,

--- a/node/magenta.ts
+++ b/node/magenta.ts
@@ -260,7 +260,7 @@ export class Magenta {
       }
 
       case "toggle": {
-        const buffers = await this.sidebar.toggle(this.options.sidebarPosition);
+        const buffers = await this.sidebar.toggle(this.options.sidebarPosition, this.options.sidebarPositionOpts);
         if (buffers && !this.mountedChatApp) {
           this.mountedChatApp = await this.chatApp.mount({
             nvim: this.nvim,

--- a/node/magenta.ts
+++ b/node/magenta.ts
@@ -90,6 +90,14 @@ export class Magenta {
 
     this.chat = new Chat({
       dispatch: this.dispatch,
+      getDisplayWidth: () => {
+        if (this.sidebar.state.state == "visible") {
+          return this.sidebar.state.displayWidth;
+        } else {
+          // a placeholder value
+          return 100;
+        }
+      },
       bufferTracker: this.bufferTracker,
       cwd: this.cwd,
       nvim: this.nvim,

--- a/node/options.ts
+++ b/node/options.ts
@@ -638,22 +638,22 @@ export function parseOptions(
     sidebarPosition: "left",
     sidebarPositionOpts: {
       above: {
-        displayHeightPercentage: 0.2,
-        inputHeightPercentage: 0.2,
+        displayHeightPercentage: 0.3,
+        inputHeightPercentage: 0.1,
       },
       below: {
-        displayHeightPercentage: 0.2,
-        inputHeightPercentage: 0.2,
+        displayHeightPercentage: 0.3,
+        inputHeightPercentage: 0.1,
       },
       tab: {
         displayHeightPercentage: 0.8,
       },
       left: {
-        widthPercentage: 0.2,
+        widthPercentage: 0.3,
         displayHeightPercentage: 0.8,
       },
       right: {
-        widthPercentage: 0.2,
+        widthPercentage: 0.3,
         displayHeightPercentage: 0.8,
       }
     },

--- a/node/options.ts
+++ b/node/options.ts
@@ -93,12 +93,34 @@ export type EditPredictionOptions = {
   profile?: EditPredictionProfile;
 };
 
+export type HSplitWindowDimensions = {
+  displayHeightPercentage: number;
+  inputHeightPercentage: number;
+};
+
+export type VSplitWindowDimensions = {
+  widthPercentage: number;
+  displayHeightPercentage: number;
+};
+
+export type TabWindowDimensions = {
+  displayHeightPercentage: number;
+};
+
 export type SidebarPositions = "left" | "right" | "below" | "above" | "tab"; 
+export type SidebarPositionOpts = {
+  left: VSplitWindowDimensions;
+  right: VSplitWindowDimensions;
+  below: HSplitWindowDimensions;
+  above: HSplitWindowDimensions;
+  tab: TabWindowDimensions;
+};
 
 export type MagentaOptions = {
   profiles: Profile[];
   activeProfile: string;
   sidebarPosition: SidebarPositions;
+  sidebarPositionOpts: SidebarPositionOpts;
   commandAllowlist: CommandAllowlist;
   autoContext: string[];
   maxConcurrentSubagents: number;
@@ -523,14 +545,118 @@ function parseSidebarPosition(
   return undefined;
 }
 
+function parseSidebarPositionOpts(
+  input: unknown,
+  logger?: { warn: (msg: string) => void },
+): SidebarPositionOpts | undefined {
+  if (typeof input !== "object" || input === null) {
+    logger?.warn("sidebarPositionOpts must be an object");
+    return undefined;
+  }
+
+  const opts = input as { [key: string]: unknown };
+  const result: Partial<SidebarPositionOpts> = {};
+
+  // Parse left/right (VSplitWindowDimensions)
+  for (const side of ["left", "right"] as const) {
+    if (side in opts) {
+      const sideOpts = opts[side];
+      if (typeof sideOpts === "object" && sideOpts !== null) {
+        const sideOptsObj = sideOpts as { [key: string]: unknown };
+        if (
+          typeof sideOptsObj["widthPercentage"] === "number" &&
+          typeof sideOptsObj["displayHeightPercentage"] === "number"
+        ) {
+          result[side] = {
+            widthPercentage: sideOptsObj["widthPercentage"],
+            displayHeightPercentage: sideOptsObj["displayHeightPercentage"],
+          };
+        } else {
+          logger?.warn(`sidebarPositionOpts.${side} must have widthPercentage and displayHeightPercentage`);
+        }
+      } else {
+        logger?.warn(`sidebarPositionOpts.${side} must be an object`);
+      }
+    }
+  }
+
+  // Parse above/below (HSplitWindowDimensions)
+  for (const side of ["above", "below"] as const) {
+    if (side in opts) {
+      const sideOpts = opts[side];
+      if (typeof sideOpts === "object" && sideOpts !== null) {
+        const sideOptsObj = sideOpts as { [key: string]: unknown };
+        if (
+          typeof sideOptsObj["displayHeightPercentage"] === "number" &&
+          typeof sideOptsObj["inputHeightPercentage"] === "number"
+        ) {
+          result[side] = {
+            displayHeightPercentage: sideOptsObj["displayHeightPercentage"],
+            inputHeightPercentage: sideOptsObj["inputHeightPercentage"],
+          };
+        } else {
+          logger?.warn(`sidebarPositionOpts.${side} must have displayHeightPercentage and inputHeightPercentage`);
+        }
+      } else {
+        logger?.warn(`sidebarPositionOpts.${side} must be an object`);
+      }
+    }
+  }
+
+  // Parse tab (TabWindowDimensions)
+  if ("tab" in opts) {
+    const tabOpts = opts["tab"];
+    if (typeof tabOpts === "object" && tabOpts !== null) {
+      const tabOptsObj = tabOpts as { [key: string]: unknown };
+      if (typeof tabOptsObj["displayHeightPercentage"] === "number") {
+        result.tab = {
+          displayHeightPercentage: tabOptsObj["displayHeightPercentage"],
+        };
+      } else {
+        logger?.warn("sidebarPositionOpts.tab must have displayHeightPercentage");
+      }
+    } else {
+      logger?.warn("sidebarPositionOpts.tab must be an object");
+    }
+  }
+
+  // Return undefined if no valid options were parsed
+  if (Object.keys(result).length === 0) {
+    return undefined;
+  }
+
+  return result as SidebarPositionOpts;
+}
+
 export function parseOptions(
   inputOptions: unknown,
-  logger: { warn: (msg: string) => void },
+  logger: { warn: (msg: string) => void, error: (msg: string) => void },
 ): MagentaOptions {
   const options: MagentaOptions = {
     profiles: [],
     activeProfile: "",
     sidebarPosition: "left",
+    sidebarPositionOpts: {
+      above: {
+        displayHeightPercentage: 0.2,
+        inputHeightPercentage: 0.2,
+      },
+      below: {
+        displayHeightPercentage: 0.2,
+        inputHeightPercentage: 0.2,
+      },
+      tab: {
+        displayHeightPercentage: 0.8,
+      },
+      left: {
+        widthPercentage: 0.2,
+        displayHeightPercentage: 0.8,
+      },
+      right: {
+        widthPercentage: 0.2,
+        displayHeightPercentage: 0.8,
+      }
+    },
     maxConcurrentSubagents: 3,
     commandAllowlist: [],
     autoContext: [],
@@ -547,6 +673,14 @@ export function parseOptions(
     );
     if (sidebarPosition) {
       options.sidebarPosition = sidebarPosition;
+    }
+
+    // Parse sidebar position opts
+    const sidebarPositionOpts = parseSidebarPositionOpts(
+      inputOptionsObj["sidebarPositionOpts"],
+    );
+    if (sidebarPositionOpts) {
+      options.sidebarPositionOpts = sidebarPositionOpts;
     }
 
     // Parse command allowlist

--- a/node/options.ts
+++ b/node/options.ts
@@ -674,11 +674,11 @@ export function parseOptions(
         displayHeightPercentage: 0.8,
       },
       left: {
-        widthPercentage: 0.3,
+        widthPercentage: 0.4,
         displayHeightPercentage: 0.8,
       },
       right: {
-        widthPercentage: 0.3,
+        widthPercentage: 0.4,
         displayHeightPercentage: 0.8,
       },
     },

--- a/node/options.ts
+++ b/node/options.ts
@@ -107,7 +107,7 @@ export type TabWindowDimensions = {
   displayHeightPercentage: number;
 };
 
-export type SidebarPositions = "left" | "right" | "below" | "above" | "tab"; 
+export type SidebarPositions = "left" | "right" | "below" | "above" | "tab" | "leftbelow" | "leftabove" | "rightbelow" | "rightabove"; 
 export type SidebarPositionOpts = {
   left: VSplitWindowDimensions;
   right: VSplitWindowDimensions;
@@ -535,11 +535,12 @@ function parseSidebarPosition(
   input: unknown,
   logger?: { warn: (msg: string) => void },
 ): SidebarPositions | undefined {
-  if (input === "right" || input === "left" || input == "above" || input == "below" || input == "tab") {
+  if (input === "right" || input === "left" || input == "above" || input == "below" || input == "tab" || 
+      input === "leftbelow" || input === "leftabove" || input === "rightbelow" || input === "rightabove") {
     return input as SidebarPositions;
   } else if (input !== undefined) {
     logger?.warn(
-      `Invalid sidebarPosition: ${JSON.stringify(input)}, must be "left", "right", "above", "below" or "tab"`,
+      `Invalid sidebarPosition: ${JSON.stringify(input)}, must be "left", "right", "above", "below", "tab", "leftbelow", "leftabove", "rightbelow", or "rightabove"`,
     );
   }
   return undefined;

--- a/node/options.ts
+++ b/node/options.ts
@@ -107,7 +107,16 @@ export type TabWindowDimensions = {
   displayHeightPercentage: number;
 };
 
-export type SidebarPositions = "left" | "right" | "below" | "above" | "tab" | "leftbelow" | "leftabove" | "rightbelow" | "rightabove"; 
+export type SidebarPositions =
+  | "left"
+  | "right"
+  | "below"
+  | "above"
+  | "tab"
+  | "leftbelow"
+  | "leftabove"
+  | "rightbelow"
+  | "rightabove";
 export type SidebarPositionOpts = {
   left: VSplitWindowDimensions;
   right: VSplitWindowDimensions;
@@ -535,8 +544,17 @@ function parseSidebarPosition(
   input: unknown,
   logger?: { warn: (msg: string) => void },
 ): SidebarPositions | undefined {
-  if (input === "right" || input === "left" || input == "above" || input == "below" || input == "tab" || 
-      input === "leftbelow" || input === "leftabove" || input === "rightbelow" || input === "rightabove") {
+  if (
+    input === "right" ||
+    input === "left" ||
+    input == "above" ||
+    input == "below" ||
+    input == "tab" ||
+    input === "leftbelow" ||
+    input === "leftabove" ||
+    input === "rightbelow" ||
+    input === "rightabove"
+  ) {
     return input as SidebarPositions;
   } else if (input !== undefined) {
     logger?.warn(
@@ -573,7 +591,9 @@ function parseSidebarPositionOpts(
             displayHeightPercentage: sideOptsObj["displayHeightPercentage"],
           };
         } else {
-          logger?.warn(`sidebarPositionOpts.${side} must have widthPercentage and displayHeightPercentage`);
+          logger?.warn(
+            `sidebarPositionOpts.${side} must have widthPercentage and displayHeightPercentage`,
+          );
         }
       } else {
         logger?.warn(`sidebarPositionOpts.${side} must be an object`);
@@ -596,7 +616,9 @@ function parseSidebarPositionOpts(
             inputHeightPercentage: sideOptsObj["inputHeightPercentage"],
           };
         } else {
-          logger?.warn(`sidebarPositionOpts.${side} must have displayHeightPercentage and inputHeightPercentage`);
+          logger?.warn(
+            `sidebarPositionOpts.${side} must have displayHeightPercentage and inputHeightPercentage`,
+          );
         }
       } else {
         logger?.warn(`sidebarPositionOpts.${side} must be an object`);
@@ -614,7 +636,9 @@ function parseSidebarPositionOpts(
           displayHeightPercentage: tabOptsObj["displayHeightPercentage"],
         };
       } else {
-        logger?.warn("sidebarPositionOpts.tab must have displayHeightPercentage");
+        logger?.warn(
+          "sidebarPositionOpts.tab must have displayHeightPercentage",
+        );
       }
     } else {
       logger?.warn("sidebarPositionOpts.tab must be an object");
@@ -631,7 +655,7 @@ function parseSidebarPositionOpts(
 
 export function parseOptions(
   inputOptions: unknown,
-  logger: { warn: (msg: string) => void, error: (msg: string) => void },
+  logger: { warn: (msg: string) => void; error: (msg: string) => void },
 ): MagentaOptions {
   const options: MagentaOptions = {
     profiles: [],
@@ -656,7 +680,7 @@ export function parseOptions(
       right: {
         widthPercentage: 0.3,
         displayHeightPercentage: 0.8,
-      }
+      },
     },
     maxConcurrentSubagents: 3,
     commandAllowlist: [],

--- a/node/options.ts
+++ b/node/options.ts
@@ -93,10 +93,12 @@ export type EditPredictionOptions = {
   profile?: EditPredictionProfile;
 };
 
+export type SidebarPositions = "left" | "right" | "below" | "above" | "tab"; 
+
 export type MagentaOptions = {
   profiles: Profile[];
   activeProfile: string;
-  sidebarPosition: "left" | "right";
+  sidebarPosition: SidebarPositions;
   commandAllowlist: CommandAllowlist;
   autoContext: string[];
   maxConcurrentSubagents: number;
@@ -510,12 +512,12 @@ function parseMCPServers(
 function parseSidebarPosition(
   input: unknown,
   logger?: { warn: (msg: string) => void },
-): "left" | "right" | undefined {
-  if (input === "right" || input === "left") {
-    return input;
+): SidebarPositions | undefined {
+  if (input === "right" || input === "left" || input == "above" || input == "below" || input == "tab") {
+    return input as SidebarPositions;
   } else if (input !== undefined) {
     logger?.warn(
-      `Invalid sidebarPosition: ${JSON.stringify(input)}, must be "left" or "right"`,
+      `Invalid sidebarPosition: ${JSON.stringify(input)}, must be "left", "right", "above", "below" or "tab"`,
     );
   }
   return undefined;

--- a/node/providers/copilot.ts
+++ b/node/providers/copilot.ts
@@ -516,7 +516,6 @@ export class CopilotProvider implements Provider {
       const input = validateInput(
         spec.name,
         JSON.parse(
-           
           (toolCall as Extract<typeof toolCall, { type: "function" }>).function
             .arguments,
         ) as Record<string, unknown>,
@@ -534,10 +533,9 @@ export class CopilotProvider implements Provider {
             }
           : {
               ...input,
-              rawRequest:
-                 
-                (toolCall as Extract<typeof toolCall, { type: "function" }>)
-                  .function.arguments,
+              rawRequest: (
+                toolCall as Extract<typeof toolCall, { type: "function" }>
+              ).function.arguments,
             };
 
       const usage: Usage = response.usage

--- a/node/sidebar.spec.ts
+++ b/node/sidebar.spec.ts
@@ -30,6 +30,194 @@ describe("node/sidebar.spec.ts", () => {
     });
   });
 
+  describe("sidebar position options", () => {
+    it("should position sidebar on the left", async () => {
+      await withDriver(
+        {
+          options: {
+            sidebarPosition: "left",
+          },
+        },
+        async (driver) => {
+          // Open a file first to have something to compare position against
+          await driver.editFile("poem.txt");
+          await driver.showSidebar();
+          const { displayWindow, inputWindow } = driver.getVisibleState();
+
+          // Find the file window
+          const fileWindow = await driver.findWindow(async (w) => {
+            const buf = await w.buffer();
+            const name = await buf.getName();
+            return name.includes("poem.txt");
+          });
+          expect(fileWindow).toBeDefined();
+
+          // Verify sidebar windows are positioned to the left of the file window
+          const displayWinPos = await displayWindow.getPosition();
+          const inputWinPos = await inputWindow.getPosition();
+          const fileWinPos = await fileWindow.getPosition();
+
+          // Left sidebar should have lower column index than file window
+          expect(displayWinPos[1]).toBeLessThan(fileWinPos[1]);
+          expect(inputWinPos[1]).toBeLessThan(fileWinPos[1]);
+
+          // Display and input windows should have same column position
+          expect(displayWinPos[1]).toBe(inputWinPos[1]);
+        },
+      );
+    });
+
+    it("should position sidebar on the right", async () => {
+      await withDriver(
+        {
+          options: {
+            sidebarPosition: "right",
+          },
+        },
+        async (driver) => {
+          // Open a file first to have something to compare position against
+          await driver.editFile("poem.txt");
+          await driver.showSidebar();
+          const { displayWindow, inputWindow } = driver.getVisibleState();
+
+          // Find the file window
+          const fileWindow = await driver.findWindow(async (w) => {
+            const buf = await w.buffer();
+            const name = await buf.getName();
+            return name.includes("poem.txt");
+          });
+          expect(fileWindow).toBeDefined();
+
+          // Verify sidebar windows are positioned to the right of the file window
+          const displayWinPos = await displayWindow.getPosition();
+          const inputWinPos = await inputWindow.getPosition();
+          const fileWinPos = await fileWindow.getPosition();
+
+          // Right sidebar should have higher column index than file window
+          expect(displayWinPos[1]).toBeGreaterThan(fileWinPos[1]);
+          expect(inputWinPos[1]).toBeGreaterThan(fileWinPos[1]);
+
+          // Display and input windows should have same column position
+          expect(displayWinPos[1]).toBe(inputWinPos[1]);
+        },
+      );
+    });
+
+    it("should position sidebar above", async () => {
+      await withDriver(
+        {
+          options: {
+            sidebarPosition: "above",
+          },
+        },
+        async (driver) => {
+          // Open a file first to have something to compare position against
+          await driver.editFile("poem.txt");
+          await driver.showSidebar();
+          const { displayWindow, inputWindow } = driver.getVisibleState();
+
+          // Find the file window
+          const fileWindow = await driver.findWindow(async (w) => {
+            const buf = await w.buffer();
+            const name = await buf.getName();
+            return name.includes("poem.txt");
+          });
+          expect(fileWindow).toBeDefined();
+
+          // Verify sidebar windows are positioned above the file window
+          const displayWinPos = await displayWindow.getPosition();
+          const inputWinPos = await inputWindow.getPosition();
+          const fileWinPos = await fileWindow.getPosition();
+
+          // Above sidebar should have lower row index than file window
+          expect(displayWinPos[0]).toBeLessThan(fileWinPos[0]);
+          expect(inputWinPos[0]).toBeLessThan(fileWinPos[0]);
+
+          // Display window should be above input window
+          expect(displayWinPos[0]).toBeLessThan(inputWinPos[0]);
+        },
+      );
+    });
+
+    it("should position sidebar below", async () => {
+      await withDriver(
+        {
+          options: {
+            sidebarPosition: "below",
+          },
+        },
+        async (driver) => {
+          // Open a file first to have something to compare position against
+          await driver.editFile("poem.txt");
+          await driver.showSidebar();
+          const { displayWindow, inputWindow } = driver.getVisibleState();
+
+          // Find the file window
+          const fileWindow = await driver.findWindow(async (w) => {
+            const buf = await w.buffer();
+            const name = await buf.getName();
+            return name.includes("poem.txt");
+          });
+          expect(fileWindow).toBeDefined();
+
+          // Verify sidebar windows are positioned below the file window
+          const displayWinPos = await displayWindow.getPosition();
+          const inputWinPos = await inputWindow.getPosition();
+          const fileWinPos = await fileWindow.getPosition();
+
+          // Below sidebar should have higher row index than file window
+          expect(displayWinPos[0]).toBeGreaterThan(fileWinPos[0]);
+          expect(inputWinPos[0]).toBeGreaterThan(fileWinPos[0]);
+
+          // Display window should be above input window
+          expect(displayWinPos[0]).toBeLessThan(inputWinPos[0]);
+        },
+      );
+    });
+
+    it("should position sidebar in a new tab", async () => {
+      await withDriver(
+        {
+          options: {
+            sidebarPosition: "tab",
+          },
+        },
+        async (driver) => {
+          // Open a file first
+          await driver.editFile("poem.txt");
+
+          // Get initial tab count
+          const initialTabCount = (await driver.nvim.call(
+            "nvim_call_function",
+            ["tabpagenr", ["$"]],
+          )) as number;
+
+          await driver.showSidebar();
+          const { displayWindow, inputWindow } = driver.getVisibleState();
+
+          // Should have created a new tab
+          const finalTabCount = await driver.nvim.call("nvim_call_function", [
+            "tabpagenr",
+            ["$"],
+          ]);
+          expect(finalTabCount).toBeGreaterThan(initialTabCount);
+
+          // Verify we're in the new tab by checking current tab
+          const currentTab = await driver.nvim.call("nvim_call_function", [
+            "tabpagenr",
+            [],
+          ]);
+          expect(currentTab).toBeGreaterThan(1);
+
+          // Display window should be above input window in the same tab
+          const displayWinPos = await displayWindow.getPosition();
+          const inputWinPos = await inputWindow.getPosition();
+          expect(displayWinPos[0]).toBeLessThan(inputWinPos[0]);
+        },
+      );
+    });
+  });
+
   it("should display and update token count in input window title", async () => {
     await withDriver({}, async (driver) => {
       await driver.showSidebar();

--- a/node/sidebar.ts
+++ b/node/sidebar.ts
@@ -12,7 +12,7 @@ import type {
   SidebarPositionOpts,
   SidebarPositions,
 } from "./options.ts";
-export const WIDTH = 100;
+
 /** Resolves responsive positions based on terminal orientation */
 function resolveResponsivePosition(
   position: SidebarPositions,
@@ -141,6 +141,7 @@ export class Sidebar {
         displayBuffer: NvimBuffer;
         inputBuffer: NvimBuffer;
         displayWindow: NvimWindow;
+        displayWidth: number;
         inputWindow: NvimWindow;
       };
 
@@ -191,7 +192,11 @@ export class Sidebar {
     sidebarPosition: SidebarPositions,
     sidebarPositionOpts: SidebarPositionOpts,
   ): Promise<
-    { displayBuffer: NvimBuffer; inputBuffer: NvimBuffer } | undefined
+    | {
+        displayBuffer: NvimBuffer;
+        inputBuffer: NvimBuffer;
+      }
+    | undefined
   > {
     if (this.state.state == "hidden") {
       return await this.show(sidebarPosition, sidebarPositionOpts);
@@ -326,6 +331,7 @@ export class Sidebar {
       displayBuffer,
       inputBuffer,
       displayWindow,
+      displayWidth,
       inputWindow,
     };
 

--- a/node/sidebar.ts
+++ b/node/sidebar.ts
@@ -7,16 +7,22 @@ import {
   type WindowId,
   type Row0Indexed,
 } from "./nvim/window.ts";
-import type { Profile, SidebarPositionOpts, SidebarPositions } from "./options.ts";
+import type {
+  Profile,
+  SidebarPositionOpts,
+  SidebarPositions,
+} from "./options.ts";
 export const WIDTH = 100;
 /** Resolves responsive positions based on terminal orientation */
 function resolveResponsivePosition(
   position: SidebarPositions,
   totalWidth: number,
-  totalHeight: number
+  totalHeight: number,
 ): SidebarPositions {
   // If not a responsive position, return as-is
-  if (!["leftbelow", "leftabove", "rightbelow", "rightabove"].includes(position)) {
+  if (
+    !["leftbelow", "leftabove", "rightbelow", "rightabove"].includes(position)
+  ) {
     return position;
   }
 
@@ -43,7 +49,7 @@ export class Sidebar {
   static async calculateWindowDimensions(
     sidebarPosition: SidebarPositions,
     sidebarPositionOpts: SidebarPositionOpts,
-    nvim: Nvim
+    nvim: Nvim,
   ): Promise<{
     inputHeight: number;
     inputWidth: number;
@@ -54,9 +60,13 @@ export class Sidebar {
     const cmdHeight = (await getOption("cmdheight", nvim)) as number;
     const windowHeight = totalHeight - cmdHeight;
     const totalWidth = (await getOption("columns", nvim)) as number;
-    
+
     // Resolve responsive positions based on terminal orientation
-    const resolvedPosition = resolveResponsivePosition(sidebarPosition, totalWidth, totalHeight);
+    const resolvedPosition = resolveResponsivePosition(
+      sidebarPosition,
+      totalWidth,
+      totalHeight,
+    );
 
     let inputHeight;
     let inputWidth;
@@ -65,31 +75,49 @@ export class Sidebar {
 
     switch (resolvedPosition) {
       case "left":
-        displayHeight = Math.floor(windowHeight * sidebarPositionOpts.left.displayHeightPercentage);
+        displayHeight = Math.floor(
+          windowHeight * sidebarPositionOpts.left.displayHeightPercentage,
+        );
         inputHeight = totalHeight - displayHeight - 2;
-        inputWidth = Math.floor(totalWidth * sidebarPositionOpts.left.widthPercentage);
+        inputWidth = Math.floor(
+          totalWidth * sidebarPositionOpts.left.widthPercentage,
+        );
         displayWidth = inputWidth;
         break;
       case "right":
-        displayHeight = Math.floor(windowHeight * sidebarPositionOpts.right.displayHeightPercentage);
+        displayHeight = Math.floor(
+          windowHeight * sidebarPositionOpts.right.displayHeightPercentage,
+        );
         inputHeight = totalHeight - displayHeight - 2;
-        inputWidth = Math.floor(totalWidth * sidebarPositionOpts.right.widthPercentage);
+        inputWidth = Math.floor(
+          totalWidth * sidebarPositionOpts.right.widthPercentage,
+        );
         displayWidth = inputWidth;
         break;
       case "above":
-        displayHeight = Math.floor(windowHeight * sidebarPositionOpts.above.displayHeightPercentage);
-        inputHeight = Math.floor(windowHeight * sidebarPositionOpts.above.inputHeightPercentage);
+        displayHeight = Math.floor(
+          windowHeight * sidebarPositionOpts.above.displayHeightPercentage,
+        );
+        inputHeight = Math.floor(
+          windowHeight * sidebarPositionOpts.above.inputHeightPercentage,
+        );
         inputWidth = totalWidth;
         displayWidth = totalWidth;
         break;
       case "below":
-        displayHeight = Math.floor(windowHeight * sidebarPositionOpts.below.displayHeightPercentage);
-        inputHeight = Math.floor(windowHeight * sidebarPositionOpts.below.inputHeightPercentage);
+        displayHeight = Math.floor(
+          windowHeight * sidebarPositionOpts.below.displayHeightPercentage,
+        );
+        inputHeight = Math.floor(
+          windowHeight * sidebarPositionOpts.below.inputHeightPercentage,
+        );
         inputWidth = totalWidth;
         displayWidth = totalWidth;
         break;
       case "tab":
-        displayHeight = Math.floor(windowHeight * sidebarPositionOpts.tab.displayHeightPercentage);
+        displayHeight = Math.floor(
+          windowHeight * sidebarPositionOpts.tab.displayHeightPercentage,
+        );
         inputHeight = totalHeight - displayHeight - 2;
         inputWidth = totalWidth;
         displayWidth = totalWidth;
@@ -173,7 +201,10 @@ export class Sidebar {
     }
   }
 
-  private async show(sidebarPosition: SidebarPositions, sidebarPositionOpts: SidebarPositionOpts): Promise<{
+  private async show(
+    sidebarPosition: SidebarPositions,
+    sidebarPositionOpts: SidebarPositionOpts,
+  ): Promise<{
     displayBuffer: NvimBuffer;
     inputBuffer: NvimBuffer;
   }> {
@@ -194,20 +225,34 @@ export class Sidebar {
       await displayBuffer.setDisplayKeymaps();
     }
 
-    const { inputHeight, inputWidth, displayHeight, displayWidth } = 
-      await Sidebar.calculateWindowDimensions(sidebarPosition, sidebarPositionOpts, this.nvim);
-   
-    // Get terminal dimensions for resolving responsive positions  
+    const { inputHeight, inputWidth, displayHeight, displayWidth } =
+      await Sidebar.calculateWindowDimensions(
+        sidebarPosition,
+        sidebarPositionOpts,
+        this.nvim,
+      );
+
+    // Get terminal dimensions for resolving responsive positions
     const totalHeight = (await getOption("lines", this.nvim)) as number;
     const totalWidth = (await getOption("columns", this.nvim)) as number;
-    const resolvedPosition = resolveResponsivePosition(sidebarPosition, totalWidth, totalHeight);
+    const resolvedPosition = resolveResponsivePosition(
+      sidebarPosition,
+      totalWidth,
+      totalHeight,
+    );
 
     let displayWindowId: WindowId;
 
     if (resolvedPosition == "tab") {
-      await this.nvim.call('nvim_command', ["tabnew"]);
-      displayWindowId = await this.nvim.call("nvim_get_current_win", []) as unknown as WindowId;
-      await this.nvim.call("nvim_win_set_buf", [displayWindowId, displayBuffer.id]);
+      await this.nvim.call("nvim_command", ["tabnew"]);
+      displayWindowId = (await this.nvim.call(
+        "nvim_get_current_win",
+        [],
+      )) as unknown as WindowId;
+      await this.nvim.call("nvim_win_set_buf", [
+        displayWindowId,
+        displayBuffer.id,
+      ]);
     } else {
       displayWindowId = (await this.nvim.call("nvim_open_win", [
         displayBuffer.id,

--- a/node/sidebar.ts
+++ b/node/sidebar.ts
@@ -161,6 +161,8 @@ export class Sidebar {
         {
           win: -1, // global split
           split: sidebarPosition,
+          height: displayHeight,
+          width: displayWidth,
         },
       ])) as WindowId;
     }
@@ -185,16 +187,10 @@ export class Sidebar {
       {
         win: displayWindow.id, // split inside this window
         split: "below",
+        height: inputHeight,
+        width: inputWidth,
       },
     ])) as WindowId;
-
-    if (sidebarPosition === "above" || sidebarPosition === "below") {
-      await this.nvim.call("nvim_win_set_height", [displayWindowId, displayHeight]);
-      await this.nvim.call("nvim_win_set_height", [inputWindowId, inputHeight]);
-    } else if (sidebarPosition === "left" || sidebarPosition === "right") {
-      await this.nvim.call("nvim_win_set_width", [displayWindowId, displayWidth]);
-      await this.nvim.call("nvim_win_set_width", [inputWindowId, inputWidth]);
-    }
 
     const inputWindow = new NvimWindow(inputWindowId, this.nvim);
     await inputWindow.clearjumps();

--- a/node/test/preamble.ts
+++ b/node/test/preamble.ts
@@ -184,6 +184,10 @@ export async function withNvimProcess(
     "nvim",
     [
       "--headless",
+      "--cmd",
+      "set columns=200",
+      "--cmd",
+      "set lines=60",
       "-n",
       "--clean",
       "--listen",

--- a/node/tools/bashCommand.spec.ts
+++ b/node/tools/bashCommand.spec.ts
@@ -449,7 +449,7 @@ tada
         await driver.assertDisplayBufferContains("⚡✅");
 
         // Verify display shows truncated text
-        const truncatedText = "A".repeat(95) + "...";
+        const truncatedText = "A".repeat(10) + "...";
         await driver.assertDisplayBufferContains(truncatedText);
 
         // Verify the full output is preserved for the agent

--- a/node/tools/bashCommand.ts
+++ b/node/tools/bashCommand.ts
@@ -19,7 +19,6 @@ import type { CommandAllowlist, MagentaOptions } from "../options.ts";
 import { getcwd } from "../nvim/nvim.ts";
 import { withTimeout } from "../utils/async.ts";
 import type { StaticTool, ToolName } from "./types.ts";
-import { WIDTH } from "../sidebar.ts";
 
 const MAX_OUTPUT_TOKENS_FOR_AGENT = 10000;
 const CHARACTERS_PER_TOKEN = 4;
@@ -148,6 +147,7 @@ export class BashCommandTool implements StaticTool {
       options: MagentaOptions;
       myDispatch: Dispatch<Msg>;
       rememberedCommands: Set<string>;
+      getDisplayWidth(): number;
     },
   ) {
     const commandAllowlist = this.context.options.commandAllowlist;
@@ -460,7 +460,7 @@ export class BashCommandTool implements StaticTool {
         currentStream = line.stream;
       }
       // Truncate line to WIDTH - 5 characters for display only
-      const displayWidth = WIDTH - 5;
+      const displayWidth = this.context.getDisplayWidth() - 5;
       const displayText =
         line.text.length > displayWidth
           ? line.text.substring(0, displayWidth) + "..."

--- a/node/tools/display-snapshot-diff.ts
+++ b/node/tools/display-snapshot-diff.ts
@@ -1,4 +1,3 @@
-import { WIDTH } from "../sidebar.ts";
 import { diffthis, getAllWindows, getcwd } from "../nvim/nvim.ts";
 import { NvimBuffer, type Line } from "../nvim/buffer.ts";
 import { type WindowId, type Row0Indexed } from "../nvim/window.ts";
@@ -12,11 +11,13 @@ export async function displaySnapshotDiff({
   messageId,
   nvim,
   fileSnapshots,
+  getDisplayWidth,
 }: {
   unresolvedFilePath: UnresolvedFilePath;
   messageId: MessageId;
   nvim: Nvim;
   fileSnapshots: FileSnapshots;
+  getDisplayWidth: () => number;
 }) {
   const absFilePath = resolveFilePath(await getcwd(nvim), unresolvedFilePath);
 
@@ -51,7 +52,6 @@ export async function displaySnapshotDiff({
     {
       win: -1, // global split
       split: "right",
-      width: WIDTH,
     },
   ])) as WindowId;
 
@@ -74,7 +74,6 @@ export async function displaySnapshotDiff({
     {
       win: fileWindowId, // global split
       split: "left",
-      width: WIDTH,
     },
   ]);
 
@@ -82,6 +81,6 @@ export async function displaySnapshotDiff({
 
   // now that both diff buffers are open, adjust the magenta window width again
   for (const window of magentaWindows) {
-    await window.setWidth(WIDTH);
+    await window.setWidth(getDisplayWidth());
   }
 }

--- a/node/tools/insert.ts
+++ b/node/tools/insert.ts
@@ -22,7 +22,6 @@ import type { StaticTool, ToolName } from "./types.ts";
 import type { NvimCwd, UnresolvedFilePath } from "../utils/files.ts";
 import type { BufferTracker } from "../buffer-tracker.ts";
 import type { ThreadId } from "../chat/types.ts";
-import { WIDTH } from "../sidebar.ts";
 
 export type State =
   | {
@@ -52,6 +51,7 @@ export class InsertTool implements StaticTool {
       nvim: Nvim;
       cwd: NvimCwd;
       dispatch: Dispatch<RootMsg>;
+      getDisplayWidth: () => number;
     },
   ) {
     this.state = { state: "processing" };
@@ -141,7 +141,7 @@ export class InsertTool implements StaticTool {
           const content = this.request.input.content;
           const lines = content.split("\n");
           const maxLines = 5;
-          const maxLength = WIDTH - 5;
+          const maxLength = this.context.getDisplayWidth() - 5;
 
           let previewLines =
             lines.length > maxLines ? lines.slice(-maxLines) : lines;

--- a/node/tools/replace.ts
+++ b/node/tools/replace.ts
@@ -23,7 +23,6 @@ import type { ThreadId } from "../chat/types";
 import type { StaticTool, ToolName } from "./types.ts";
 import type { NvimCwd, UnresolvedFilePath } from "../utils/files.ts";
 import type { BufferTracker } from "../buffer-tracker.ts";
-import { WIDTH } from "../sidebar.ts";
 export type State =
   | {
       state: "processing";
@@ -52,6 +51,7 @@ export class ReplaceTool implements StaticTool {
       bufferTracker: BufferTracker;
       cwd: NvimCwd;
       nvim: Nvim;
+      getDisplayWidth(): number;
     },
   ) {
     this.state = { state: "processing" };
@@ -214,7 +214,7 @@ export class ReplaceTool implements StaticTool {
     const diffLines = diffResult.split("\n").slice(5);
 
     const maxLines = 10;
-    const maxLength = WIDTH - 5;
+    const maxLength = this.context.getDisplayWidth() - 5;
 
     let previewLines =
       diffLines.length > maxLines

--- a/node/tools/toolManager.ts
+++ b/node/tools/toolManager.ts
@@ -197,6 +197,7 @@ export class ToolManager {
       dispatch: Dispatch<RootMsg>;
       mcpToolManager: MCPToolManager;
       bufferTracker: BufferTracker;
+      getDisplayWidth: () => number;
       threadId: ThreadId;
       nvim: Nvim;
       lsp: Lsp;
@@ -484,6 +485,7 @@ export class ToolManager {
                   }),
                 options: this.context.options,
                 rememberedCommands: this.context.chat.rememberedCommands,
+                getDisplayWidth: this.context.getDisplayWidth,
               },
             );
 


### PR DESCRIPTION
Closes https://github.com/dlants/magenta.nvim/issues/165 by providing more options to work with a vertical monitor, below, above, tab.

Note: It looks like there is a limitation in adding the "floating" option since Magenta.nvim relies in splitting the container window and based on my experimentation, it looks like splitting is not supported in floating window, however the "tab" options also covers this need pretty well.

# 


<table>
<tr>
<th colspan="3">
As tab in landscape orientation
</th>
</tr>
<tr>
<td colspan="3">
<img height="500" alt="image" src="https://github.com/user-attachments/assets/2140dec4-b6c9-4f06-b42c-cd0c892861c1" />
</td>
</tr>
<tr>
<th>
As tab in portrait orientation
</th>
<th>
As split above
</th>
<th>
As split below
</th>
</tr>
<tr>
<td>
<img height="500" alt="image" src="https://github.com/user-attachments/assets/44926dfc-7546-4567-9dbf-42cc6623be2d" />
</td>
<td>
<img height="500" alt="image" src="https://github.com/user-attachments/assets/38bbca1c-7e6d-48b5-bf03-d6e21dda2f1a" />
</td>
<td>
<img height="500" alt="image" src="https://github.com/user-attachments/assets/db1e41c6-575a-475d-bd4c-5c0f47fb5459" />
</td>
</tr>
<tr>
<th colspan="3">
As split left
</th>
</tr>
<tr>
<td colspan="3">
<img height="500" alt="image" src="https://github.com/user-attachments/assets/eaefa1ef-3843-4648-89bd-c99e77f36d37" />
</td>
</tr>
<tr>
<th colspan="3">
As split right
</th>
</tr>
<tr>
<td colspan="3">
<img height="500" alt="image" src="https://github.com/user-attachments/assets/ab03cfbb-15f8-47fc-996c-58aa5080569a" />
</td>
</tr>
</table>
