### PR TITLE
use markdown as filetype for magenta buffer

### DIFF
--- a/node/sidebar.ts
+++ b/node/sidebar.ts
@@ -227,6 +227,7 @@ export class Sidebar {
       await displayBuffer.setOption("bufhidden", "hide");
       await displayBuffer.setOption("buftype", "nofile");
       await displayBuffer.setOption("swapfile", false);
+      await displayBuffer.setOption("filetype", "markdown");
       await displayBuffer.setDisplayKeymaps();
     }
 


### PR DESCRIPTION
Currently, Magenta uses extmarks for styling because purely using Markdown didn't work (see README). But ideally, we still have the markdown styling for things like codeblocks, bold text in the response from the LLM. We can have the best of both worlds by setting the filetype of the buffer to `markdown` while still using extmarks.

Currently, this is how we render things like code snippets that do not relate to changes made by the LLM

<img width="1175" height="1117" alt="Screenshot 2025-09-05 at 12 00 31 PM" src="https://github.com/user-attachments/assets/a6ca108c-de46-47c2-9824-e284eee02439" />

And now with Markdown as the buffer filetype:

<img width="1172" height="1117" alt="Screenshot 2025-09-05 at 12 01 48 PM" src="https://github.com/user-attachments/assets/cb2a7083-fd81-4056-a7de-1a76d5dc6f04" />


Even when interacting with agents and files, I haven't found this to cause issues (see video below). Am I correctly testing for the cases that caused things to crash when Markdown was tried previously?



https://github.com/user-attachments/assets/1f297470-f29b-4943-a6e9-b9f0acea5e06

