### PR TITLE
add authType support to edit predictions

### DIFF
--- a/node/edit-prediction/edit-prediction-controller.ts
+++ b/node/edit-prediction/edit-prediction-controller.ts
@@ -747,6 +747,9 @@ Predict the most likely next edit the user will make.`;
       if (predictionProfile.apiKeyEnvVar) {
         profile.apiKeyEnvVar = predictionProfile.apiKeyEnvVar;
       }
+      if (predictionProfile.authType) {
+        profile.authType = predictionProfile.authType;
+      }
 
       return profile;
     }
@@ -759,6 +762,7 @@ Predict the most likely next edit the user will make.`;
       model: profile.model,
       baseUrl: profile.baseUrl,
       apiKeyEnvVar: profile.apiKeyEnvVar,
+      authType: profile.authType,
     };
   }
 

--- a/node/options.ts
+++ b/node/options.ts
@@ -210,6 +210,19 @@ function parseEditPredictionProfile(
     }
   }
 
+  if ("authType" in p) {
+    if (
+      typeof p["authType"] === "string" &&
+      (p["authType"] === "key" || p["authType"] === "max")
+    ) {
+      profile.authType = p["authType"];
+    } else {
+      logger.warn(
+        'Invalid authType in editPrediction.profile, must be "key" or "max"',
+      );
+    }
+  }
+
   return profile;
 }
 


### PR DESCRIPTION
Was trying out magenta today and specifically playing with the next edit prediction feature. It did not work with my claude max subscription. This PR fixes that.

I did not add tests because they where somewhat awkward as `resolvePredictionProfile` is private. So I just left them out. Happy to add in a followup if you feel like its needed.

Disclaimer: The code was written in collab with claude code.