### PR TITLE
Claude "Anthropic Console Account" auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The project includes a sample Dockerfile at `docker/Dockerfile`. See
 - Agent tier system: agents have `leaf`, `thread`, or `orchestrator` tiers that control spawn permissions. New `worktree` orchestrator agent replaces the conductor. New `:Magenta agent <name>` command.
 - Test segmentation: `TEST_MODE` env var splits tests into sandbox (local) and full-capabilities (docker) modes. New `tests-in-sandbox` subagent for fast local feedback.
 - Renamed the `docs` tool to `learn` tool.
+- Claude Code keychain auth: new `authType = "keychain"` profile option (macOS) reuses the Anthropic Console API key that Claude Code stores in the login Keychain, for users on the "Anthropic Console Account (API usage billing)" sign-in mode.
 
 ## Mar 2026
 
@@ -202,6 +203,7 @@ require('magenta').setup({
 ## Supported Providers
 
 - **anthropic** - Claude models via [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-typescript)
+  - Supports three auth modes: `authType = "key"` (env var), `authType = "max"` (OAuth with your Claude subscription), and `authType = "keychain"` (macOS only — reads the Anthropic Console API key Claude Code stored in the login Keychain).
 
 See `:help magenta-providers` for detailed provider configuration.
 

--- a/doc/magenta-config.txt
+++ b/doc/magenta-config.txt
@@ -35,7 +35,9 @@ Each profile specifies:
   - `provider`: "anthropic"
   - `model`: the specific model to use
   - `fastModel`: (optional) model for lightweight tasks
-  - `authType`: (optional) "key" (default) or "max" for Anthropic OAuth
+  - `authType`: (optional) "key" (default), "max" for Anthropic OAuth,
+    or "keychain" to load a Claude Code Console API key from the macOS
+    Keychain (see |magenta-claude-keychain|)
   - `apiKeyEnvVar`: environment variable containing the API key
   - `baseUrl`: (optional) custom API endpoint
 

--- a/doc/magenta-providers.txt
+++ b/doc/magenta-providers.txt
@@ -63,6 +63,34 @@ How it works:~
   - Tokens stored in `~/.local/share/magenta/auth.json` (0600 permissions)
   - Refresh tokens managed automatically
 
+                                                    *magenta-claude-keychain*
+CLAUDE CODE KEYCHAIN AUTHENTICATION ~
+
+On macOS, reuse the Anthropic Console API key that Claude Code stores in
+the login Keychain (the "Anthropic Console Account" / API-usage-billing
+sign-in mode of Claude Code). Magenta will load the key from the Keychain
+at startup; no environment variable is required.
+>lua
+    {
+      name = "claude-keychain",
+      provider = "anthropic",
+      model = "claude-sonnet-4-5",
+      authType = "keychain"
+      -- No apiKeyEnvVar needed
+    }
+<
+
+How it works:~
+  - Runs `security find-generic-password -s "Claude Code" -a $USER -w`
+    to read the `sk-ant-*` key Claude Code stored in the login Keychain
+  - Requests include the Claude Code system-prompt shim, since some orgs
+    restrict console-managed keys to Claude-Code-shaped traffic
+  - macOS only; on other platforms this auth type is a no-op and requests
+    will fail without an API key
+
+Requires: You must have signed into Claude Code using the "Anthropic
+Console Account (API usage billing)" option at least once on this machine.
+
 ==============================================================================
 DEPRECATED PROVIDERS                            *magenta-deprecated-providers*
                                                              *magenta-openai*

--- a/doc/magenta-providers.txt
+++ b/doc/magenta-providers.txt
@@ -67,7 +67,7 @@ How it works:~
 CLAUDE CODE KEYCHAIN AUTHENTICATION ~
 
 On macOS, reuse the Anthropic Console API key that Claude Code stores in
-the login Keychain (the "Anthropic Console Account" / API-usage-billing
+the login Keychain (after authentication with the "Anthropic Console Account" / API-usage-billing
 sign-in mode of Claude Code). Magenta will load the key from the Keychain
 at startup; no environment variable is required.
 >lua
@@ -85,7 +85,6 @@ How it works:~
     to read the `sk-ant-*` key Claude Code stored in the login Keychain
   - Requests include the Claude Code system-prompt shim, since some orgs
     restrict console-managed keys to Claude-Code-shaped traffic
-  - macOS only; on other platforms this auth type is a no-op and requests
     will fail without an API key
 
 Requires: You must have signed into Claude Code using the "Anthropic

--- a/doc/tags
+++ b/doc/tags
@@ -35,6 +35,7 @@ magenta-bellOnNotify	magenta-config.txt	/*magenta-bellOnNotify*
 magenta-builtin-agents	magenta-subagents.txt	/*magenta-builtin-agents*
 magenta-chimeVolume	magenta-config.txt	/*magenta-chimeVolume*
 magenta-claude-max	magenta-providers.txt	/*magenta-claude-max*
+magenta-claude-keychain	magenta-providers.txt	/*magenta-claude-keychain*
 magenta-commands-keymaps-contents	magenta-commands-keymaps.txt	/*magenta-commands-keymaps-contents*
 magenta-commands-keymaps.txt	magenta-commands-keymaps.txt	/*magenta-commands-keymaps.txt*
 magenta-completions	magenta-commands-keymaps.txt	/*magenta-completions*

--- a/lua/magenta/options.lua
+++ b/lua/magenta/options.lua
@@ -21,6 +21,12 @@ local defaults = {
       authType = "max"
     },
     {
+      name = "claude-keychain",
+      provider = "anthropic",
+      model = "claude-opus-4-6",
+      authType = "keychain"
+    },
+    {
       name = "gpt-4o",
       provider = "openai",
       model = "gpt-4o",

--- a/node/core/src/provider-options.ts
+++ b/node/core/src/provider-options.ts
@@ -19,7 +19,7 @@ export type ProviderProfile = {
   fastModel: string;
   baseUrl?: string;
   apiKeyEnvVar?: string;
-  authType?: "key" | "max";
+  authType?: "key" | "max" | "keychain";
   promptCaching?: boolean;
   env?: Record<string, string>;
   thinking?:

--- a/node/core/src/providers/anthropic-agent.ts
+++ b/node/core/src/providers/anthropic-agent.ts
@@ -19,7 +19,7 @@ import type {
 } from "./provider-types.ts";
 
 export type AnthropicAgentOptions = {
-  authType: "key" | "max";
+  authType: "key" | "max" | "keychain";
   includeWebSearch: boolean;
   disableParallelToolUseFlag: boolean;
   logger: Logger;
@@ -729,7 +729,7 @@ export class AnthropicAgent extends Emitter<AgentEvents> implements Agent {
       },
     ];
 
-    if (authType === "max") {
+    if (authType === "max" || authType === "keychain") {
       systemBlocks.unshift({
         type: "text" as const,
         text: CLAUDE_CODE_SPOOF_PROMPT,

--- a/node/core/src/providers/anthropic.ts
+++ b/node/core/src/providers/anthropic.ts
@@ -1,3 +1,5 @@
+import { execSync } from "node:child_process";
+import { userInfo } from "node:os";
 import Anthropic from "@anthropic-ai/sdk";
 import type { AnthropicAuth } from "../anthropic-auth.ts";
 import type { AuthUI } from "../auth-ui.ts";
@@ -60,7 +62,7 @@ type MessageStreamParams = Omit<
 
 export class AnthropicProvider implements Provider {
   protected client: Anthropic;
-  private authType: "key" | "max";
+  private authType: "key" | "max" | "keychain";
   private validateInput: ValidateInput;
   private auth: AnthropicAuth | undefined;
   private pendingOAuthFlow: Promise<void> | undefined;
@@ -73,7 +75,7 @@ export class AnthropicProvider implements Provider {
     options?: {
       baseUrl?: string | undefined;
       apiKeyEnvVar?: string | undefined;
-      authType?: "key" | "max" | undefined;
+      authType?: "key" | "max" | "keychain" | undefined;
       disableParallelToolUseFlag?: boolean;
     },
   ) {
@@ -88,9 +90,14 @@ export class AnthropicProvider implements Provider {
         baseURL: options?.baseUrl,
         fetch: this.createOAuthFetch(),
       });
+    } else if (this.authType === "keychain") {
+      const apiKey = loadApiKeyFromKeychain(logger);
+      this.client = new Anthropic({
+        apiKey,
+        baseURL: options?.baseUrl,
+      });
     } else {
-      const apiKeyEnvVar = options?.apiKeyEnvVar || "ANTHROPIC_API_KEY";
-      const apiKey = process.env[apiKeyEnvVar];
+      const apiKey = process.env[options?.apiKeyEnvVar || "ANTHROPIC_API_KEY"];
 
       this.client = new Anthropic({
         apiKey,
@@ -139,7 +146,6 @@ export class AnthropicProvider implements Provider {
   private async ensureValidToken(): Promise<void> {
     const isAuthenticated = await this.auth!.isAuthenticated();
     if (!isAuthenticated) {
-      // Coalesce concurrent auth attempts into a single OAuth flow
       if (!this.pendingOAuthFlow) {
         this.pendingOAuthFlow = this.triggerOAuthFlow().finally(() => {
           this.pendingOAuthFlow = undefined;
@@ -402,7 +408,7 @@ export class AnthropicProvider implements Provider {
       },
     ];
 
-    if (this.authType === "max") {
+    if (this.authType === "max" || this.authType === "keychain") {
       systemBlocks.unshift({
         type: "text" as const,
         text: CLAUDE_CODE_SPOOF_PROMPT,
@@ -497,7 +503,7 @@ export class AnthropicProvider implements Provider {
       },
     ];
 
-    if (this.authType === "max") {
+    if (this.authType === "max" || this.authType === "keychain") {
       systemBlocks.unshift({
         type: "text" as const,
         text: CLAUDE_CODE_SPOOF_PROMPT,
@@ -687,5 +693,31 @@ export class AnthropicProvider implements Provider {
       logger: this.logger,
       validateInput: this.validateInput,
     });
+  }
+}
+
+function loadApiKeyFromKeychain(logger: Logger): string | undefined {
+  if (process.platform !== "darwin") {
+    logger.warn("Keychain auth is only supported on macOS");
+    return undefined;
+  }
+
+  try {
+    const username = userInfo().username;
+    const apiKey = execSync(
+      `security find-generic-password -s "Claude Code" -a "${username}" -w 2>/dev/null`,
+      { encoding: "utf-8" },
+    ).trim();
+
+    if (apiKey?.startsWith("sk-ant-")) {
+      logger.info("Loaded API key from macOS Keychain (Claude Code)");
+      return apiKey;
+    }
+
+    logger.warn("Could not find Claude Code API key in macOS Keychain");
+    return undefined;
+  } catch (e) {
+    logger.error(`Error loading from keychain: ${e as Error}`);
+    return undefined;
   }
 }

--- a/node/options.ts
+++ b/node/options.ts
@@ -52,7 +52,7 @@ export type Profile = {
   fastModel: string;
   baseUrl?: string;
   apiKeyEnvVar?: string;
-  authType?: "key" | "max"; // New field for authentication type
+  authType?: "key" | "max" | "keychain"; // New field for authentication type
   promptCaching?: boolean; // Primarily used by Bedrock provider
   env?: Record<string, string>; // Environment variables to set before provider initialization (e.g., AWS_PROFILE, AWS_REGION)
   thinking?:
@@ -298,12 +298,14 @@ function parseProfiles(
       if ("authType" in p) {
         if (
           typeof p.authType === "string" &&
-          (p.authType === "key" || p.authType === "max")
+          (p.authType === "key" ||
+            p.authType === "max" ||
+            p.authType === "keychain")
         ) {
           out.authType = p.authType;
         } else {
           logger.warn(
-            `Invalid authType in profile ${p.name}, must be "key" or "max"`,
+            `Invalid authType in profile ${p.name}, must be "key", "max", or "keychain"`,
           );
         }
       }


### PR DESCRIPTION
This PR adds a new auth method to use claude code's auth. 

Currently magenta supports "max" authentication from claude code but when logging into claude code with the "Anthropic Console Account" method, the credentials are stored differently (in Keychain on mac).

<img width="819" height="388" alt="Screenshot 2026-04-17 at 12 54 02 AM" src="https://github.com/user-attachments/assets/d752a5cc-b7db-4d92-ab55-83aaf312288c" />

This PR adds `keychain` as an auth mode which pulls the api key from the keychain and uses that for auth.